### PR TITLE
Update module.css

### DIFF
--- a/HotWax_2021/Custom Modules/Mega Menu Module.module/module.css
+++ b/HotWax_2021/Custom Modules/Mega Menu Module.module/module.css
@@ -33,6 +33,7 @@
     transition: all 200ms ease;
     display: inline-block;
     overflow: visible !important;
+    line-height: 1.8em;
     max-width: none !important;
     width: auto !important;
     font-family: 'Open Sans',sans-serif;
@@ -76,6 +77,8 @@
 }
 .mega-menu-list-sub-items ul{
   padding: 0px;
+  line-height: 1.8em;
+  margin-top:0;
 }
 .mega-menu-list-main:nth-child(5) .mega-menu-list-items a::after{
   display: none;


### PR DESCRIPTION
update the stylings of navlinks and ul inside it because some pages not contain main.css file so they dont able to use the global properties written in that . Thats why we should write these styles to not depend on global style .

Before:
![image](https://github.com/user-attachments/assets/695041f4-553e-4696-aa66-6a6ddc8b9cd3)

After :
![image](https://github.com/user-attachments/assets/5bb89f4a-62eb-4306-b4f0-a8f4a75b861b)
