### PR TITLE
Add color of li in ordered list .

### DIFF
--- a/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css
+++ b/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css
@@ -1478,10 +1478,14 @@ span.time-wrap span img {
     padding-left: 40px !important;
     font-weight: 300;
 }
-
+.blog-post-sections .section.post-body ol li {
+  color: #666666;
+  font-size: 16px;
+}
 .blog-post-sections .section.post-body ol li:has(h3)::marker {
     font-size: 20px;
     font-weight: bold;
+    color: #000000;
 }
 
 .topic-wrap p {


### PR DESCRIPTION
Add a color of list item in ordered list so that the marker inherit the color of list item . so color of marker and text will be same .
Add one more changes when we have h3 inside li , color of marker should be black and bold

Before : 
![image](https://github.com/user-attachments/assets/70b54577-1f61-4010-baec-f32206447cc5)

After : 
![image](https://github.com/user-attachments/assets/6d107c34-8957-41b2-886d-2768f4292d60)
