### PR TITLE
Update : Width of Header

### DIFF
--- a/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css
+++ b/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css
@@ -99,7 +99,11 @@ img {
   max-width: 1178px;
   margin-inline: auto;
 }
-
+.custom-header-wrapper .row-fluid .page-center{
+  max-width: 100%;
+  margin: 0 90px;
+  width: calc(100% - 180px);
+}
 a img {
   vertical-align: middle;
 }


### PR DESCRIPTION
closes #36 

Fixed max-width of the header, so that header is not appears in center , use dynamic width calculation which helps header to looks same on every screen size.

Before :
![image](https://github.com/user-attachments/assets/ae6597b5-16fb-4749-93fd-0a0969f07c61)

After:
![image](https://github.com/user-attachments/assets/4183968c-70a7-430b-a740-9b3e4d2fe7be)
