### PR TITLE
add: wrap text content in a div

### DIFF
--- a/Nixon/modules/team-v2.module/module.html
+++ b/Nixon/modules/team-v2.module/module.html
@@ -54,7 +54,8 @@
 						{% endif %}
 {% endif %}
 					</div>
-					<div class="team_cnt"> 
+					<div class="team_cnt">
+						<div class="team_cnt_body" style="height: 125px">
 						{% if item.member_name %}
 						{% set href = item.link_field.url.href %}
 						{% if item.link_field.url.type is equalto "EMAIL_ADDRESS" %}
@@ -73,7 +74,8 @@
 						{% if item.content %} 
 						<div class="team_cnt_inr"> 
 							{{ item.content }}
-						</div> 
+						</div>
+						</div>
 						{% endif %}
 						{% if item.link_text %}
 						<div class="team_btn">


### PR DESCRIPTION
Wrap text content in a div and gives certain height to it so that cta button in all cards looks aligned 

Before : 
![image](https://github.com/user-attachments/assets/d42943cb-459e-48f8-9389-6814c182da1e)

After : 
![image](https://github.com/user-attachments/assets/054000b3-832d-42e5-a38c-9e0c8c412fb4)
