### PR TITLE
[codex] Add reusable pricing page modules

### DIFF
--- a/hotwax-theme/modules/general-banner.module/fields.json
+++ b/hotwax-theme/modules/general-banner.module/fields.json
@@ -1,0 +1,154 @@
+[ {
+  "id": "show_banner",
+  "name": "show_banner",
+  "label": "Show banner",
+  "required": false,
+  "locked": false,
+  "display": "checkbox",
+  "type": "boolean",
+  "default": true
+}, {
+  "id": "anchor_id",
+  "name": "anchor_id",
+  "label": "Anchor ID",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": ""
+}, {
+  "id": "title",
+  "name": "title",
+  "label": "Title",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": "Page banner title"
+}, {
+  "id": "subtitle",
+  "name": "subtitle",
+  "label": "Subtitle",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": ""
+}, {
+  "id": "body",
+  "name": "body",
+  "label": "Body",
+  "required": false,
+  "locked": false,
+  "type": "richtext",
+  "default": "<p>Add supporting copy for this section.</p>"
+}, {
+  "id": "buttons",
+  "name": "buttons",
+  "label": "Buttons",
+  "required": false,
+  "locked": false,
+  "occurrence": {
+    "min": 0,
+    "max": 2,
+    "sorting_label_field": "button_label",
+    "default": 2
+  },
+  "children": [ {
+    "id": "button_label",
+    "name": "button_label",
+    "label": "Label",
+    "required": false,
+    "locked": false,
+    "allow_new_line": false,
+    "type": "text",
+    "default": "Button"
+  }, {
+    "id": "link_type",
+    "name": "link_type",
+    "label": "Link type",
+    "required": false,
+    "locked": false,
+    "display": "select",
+    "choices": [ [ "link", "Link" ], [ "anchor", "Anchor" ] ],
+    "multiple": false,
+    "type": "choice",
+    "default": "link"
+  }, {
+    "id": "link",
+    "name": "link",
+    "label": "Link",
+    "required": false,
+    "locked": false,
+    "supported_types": [ "EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS", "BLOG" ],
+    "show_advanced_rel_options": false,
+    "type": "link",
+    "default": {
+      "url": {
+        "type": "EXTERNAL",
+        "href": ""
+      },
+      "open_in_new_tab": false,
+      "no_follow": false
+    }
+  }, {
+    "id": "anchor_target",
+    "name": "anchor_target",
+    "label": "Anchor target",
+    "required": false,
+    "locked": false,
+    "allow_new_line": false,
+    "type": "text",
+    "default": ""
+  }, {
+    "id": "button_style",
+    "name": "button_style",
+    "label": "Button style",
+    "required": false,
+    "locked": false,
+    "display": "select",
+    "choices": [ [ "primary", "Primary" ], [ "secondary", "Secondary" ], [ "simple", "Simple" ], [ "tertiary", "Tertiary" ] ],
+    "multiple": false,
+    "type": "choice",
+    "default": "primary"
+  } ],
+  "type": "group",
+  "default": [ {
+    "button_label": "Primary action",
+    "link_type": "link",
+    "link": {
+      "url": {
+        "type": "EXTERNAL",
+        "href": ""
+      },
+      "open_in_new_tab": false,
+      "no_follow": false
+    },
+    "anchor_target": "",
+    "button_style": "primary"
+  }, {
+    "button_label": "Secondary action",
+    "link_type": "anchor",
+    "link": {
+      "url": {
+        "type": "EXTERNAL",
+        "href": ""
+      },
+      "open_in_new_tab": false,
+      "no_follow": false
+    },
+    "anchor_target": "",
+    "button_style": "secondary"
+  } ]
+}, {
+  "id": "alignment",
+  "name": "alignment",
+  "label": "Alignment",
+  "required": false,
+  "locked": false,
+  "display": "select",
+  "choices": [ [ "left", "Left" ], [ "center", "Center" ] ],
+  "multiple": false,
+  "type": "choice",
+  "default": "left"
+} ]

--- a/hotwax-theme/modules/general-banner.module/fields.json
+++ b/hotwax-theme/modules/general-banner.module/fields.json
@@ -35,9 +35,9 @@
   "type": "text",
   "default": ""
 }, {
-  "id": "body",
-  "name": "body",
-  "label": "Body",
+  "id": "description",
+  "name": "description",
+  "label": "Description",
   "required": false,
   "locked": false,
   "type": "richtext",

--- a/hotwax-theme/modules/general-banner.module/meta.json
+++ b/hotwax-theme/modules/general-banner.module/meta.json
@@ -1,0 +1,7 @@
+{
+  "global": false,
+  "content_types": [ "LANDING_PAGE", "SITE_PAGE" ],
+  "host_template_types": [ "PAGE" ],
+  "label": "General banner",
+  "is_available_for_new_content": true
+}

--- a/hotwax-theme/modules/general-banner.module/module.css
+++ b/hotwax-theme/modules/general-banner.module/module.css
@@ -1,0 +1,50 @@
+.general-banner {
+  max-width: var(--content-width, 1200px);
+  margin-inline: auto;
+  padding-block: var(--spacer-xl);
+  padding-inline: var(--spacer-md);
+}
+
+.general-banner--center {
+  text-align: center;
+}
+
+.general-banner__content {
+  max-width: 1200px;
+}
+
+.general-banner--center .general-banner__content {
+  margin-inline: auto;
+}
+
+.general-banner__title,
+.general-banner__subtitle,
+.general-banner__body {
+  margin-bottom: var(--spacer-md);
+}
+
+.general-banner__body > *:last-child {
+  margin-bottom: 0;
+}
+
+.general-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacer-sm);
+  margin-top: var(--spacer-md);
+}
+
+.general-banner--center .general-banner__actions {
+  justify-content: center;
+}
+
+@media (max-width: 767px) {
+  .general-banner {
+    padding-inline: var(--spacer-sm);
+  }
+
+  .general-banner__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/hotwax-theme/modules/general-banner.module/module.css
+++ b/hotwax-theme/modules/general-banner.module/module.css
@@ -1,5 +1,5 @@
 .general-banner {
-  max-width: var(--content-width, 1200px);
+  max-width: var(--page-max-width, 1200px);
   margin-inline: auto;
   padding-block: 72px 44px;
   padding-inline: 0;

--- a/hotwax-theme/modules/general-banner.module/module.css
+++ b/hotwax-theme/modules/general-banner.module/module.css
@@ -1,8 +1,8 @@
 .general-banner {
   max-width: var(--content-width, 1200px);
   margin-inline: auto;
-  padding-block: var(--spacer-xl);
-  padding-inline: var(--spacer-md);
+  padding-block: 72px 44px;
+  padding-inline: 0;
 }
 
 .general-banner--center {
@@ -17,10 +17,33 @@
   margin-inline: auto;
 }
 
-.general-banner__title,
-.general-banner__subtitle,
+.general-banner__title {
+  color: #1e1e1e;
+  font-family: "Open Sans Condensed", "Open Sans", sans-serif;
+  font-size: 72px;
+  font-weight: 700;
+  letter-spacing: -2.16px;
+  line-height: 1.2;
+  margin: 0 0 28px;
+}
+
+.general-banner__subtitle {
+  color: #2d2d2d;
+  font-family: "Open Sans", sans-serif;
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 1.3;
+  margin: 0 0 28px;
+  max-width: 1120px;
+}
+
 .general-banner__body {
-  margin-bottom: var(--spacer-md);
+  color: #5f6368;
+  font-family: "Open Sans", sans-serif;
+  font-size: 18px;
+  line-height: 1.3;
+  margin-bottom: 0;
+  max-width: 1120px;
 }
 
 .general-banner__body > *:last-child {
@@ -30,8 +53,22 @@
 .general-banner__actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--spacer-sm);
-  margin-top: var(--spacer-md);
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.general-banner__actions .button {
+  border-radius: 9999px;
+  box-shadow: none;
+  color: #ffffff !important;
+  justify-content: center;
+  min-height: 45px;
+  padding: 8px 24px;
+}
+
+.general-banner__actions .button.button--secondary {
+  background-color: #ffffff;
+  color: #ec2227 !important;
 }
 
 .general-banner--center .general-banner__actions {
@@ -40,7 +77,17 @@
 
 @media (max-width: 767px) {
   .general-banner {
-    padding-inline: var(--spacer-sm);
+    padding-block: 48px 28px;
+    padding-inline: 20px;
+  }
+
+  .general-banner__title {
+    font-size: 44px;
+    letter-spacing: -1.32px;
+  }
+
+  .general-banner__subtitle {
+    font-size: 28px;
   }
 
   .general-banner__actions {

--- a/hotwax-theme/modules/general-banner.module/module.html
+++ b/hotwax-theme/modules/general-banner.module/module.html
@@ -2,11 +2,11 @@
   <section class="general-banner general-banner--{{ module.alignment|default('left') }}"{% if module.anchor_id %} id="{{ module.anchor_id|escape_attr }}"{% endif %}>
     <div class="general-banner__content">
       {% if module.title %}
-        <h1 class="general-banner__title">{{ module.title }}</h1>
+        <h1 class="general-banner__title">{{ module.title|escape }}</h1>
       {% endif %}
 
       {% if module.subtitle %}
-        <h2 class="general-banner__subtitle">{{ module.subtitle }}</h2>
+        <h2 class="general-banner__subtitle">{{ module.subtitle|escape }}</h2>
       {% endif %}
 
       {% if module.description %}
@@ -21,18 +21,20 @@
             {% if item.link_type == "anchor" %}
               {% set href = "#" ~ item.anchor_target %}
             {% else %}
-              {% set href = item.link.url.href %}
-              {% if item.link.url.type is equalto "EMAIL_ADDRESS" %}
+              {% set href = item.link.url.href if item.link and item.link.url else "" %}
+              {% if item.link and item.link.url and item.link.url.type is equalto "EMAIL_ADDRESS" %}
                 {% set href = "mailto:" ~ href %}
               {% endif %}
             {% endif %}
-            {% set rel = (item.link.open_in_new_tab ? "noopener " : "") ~ (item.link.no_follow ? "nofollow" : "") %}
+            {% set open_in_new_tab = item.link.open_in_new_tab if item.link else false %}
+            {% set no_follow = item.link.no_follow if item.link else false %}
+            {% set rel = (open_in_new_tab ? "noopener " : "") ~ (no_follow ? "nofollow" : "") %}
 
             <a href="{{ href|default('#') }}"
                class="button{% if item.button_style == 'secondary' %} button--secondary{% elif item.button_style == 'tertiary' %} button--tertiary{% elif item.button_style == 'simple' %} button--simple{% endif %}"
-               {% if item.link.open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %}
+               {% if open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %}
                {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
-              {{ item.button_label }}
+              {{ item.button_label|escape }}
             </a>
           {% endfor %}
         </div>

--- a/hotwax-theme/modules/general-banner.module/module.html
+++ b/hotwax-theme/modules/general-banner.module/module.html
@@ -9,9 +9,9 @@
         <h2 class="general-banner__subtitle">{{ module.subtitle }}</h2>
       {% endif %}
 
-      {% if module.body %}
+      {% if module.description %}
         <div class="general-banner__body">
-          {{ module.body }}
+          {{ module.description }}
         </div>
       {% endif %}
 

--- a/hotwax-theme/modules/general-banner.module/module.html
+++ b/hotwax-theme/modules/general-banner.module/module.html
@@ -1,0 +1,42 @@
+{% if module.show_banner %}
+  <section class="general-banner general-banner--{{ module.alignment|default('left') }}"{% if module.anchor_id %} id="{{ module.anchor_id|escape_attr }}"{% endif %}>
+    <div class="general-banner__content">
+      {% if module.title %}
+        <h1 class="general-banner__title">{{ module.title }}</h1>
+      {% endif %}
+
+      {% if module.subtitle %}
+        <h2 class="general-banner__subtitle">{{ module.subtitle }}</h2>
+      {% endif %}
+
+      {% if module.body %}
+        <div class="general-banner__body">
+          {{ module.body }}
+        </div>
+      {% endif %}
+
+      {% if module.buttons %}
+        <div class="general-banner__actions">
+          {% for item in module.buttons %}
+            {% if item.link_type == "anchor" %}
+              {% set href = "#" ~ item.anchor_target %}
+            {% else %}
+              {% set href = item.link.url.href %}
+              {% if item.link.url.type is equalto "EMAIL_ADDRESS" %}
+                {% set href = "mailto:" ~ href %}
+              {% endif %}
+            {% endif %}
+            {% set rel = (item.link.open_in_new_tab ? "noopener " : "") ~ (item.link.no_follow ? "nofollow" : "") %}
+
+            <a href="{{ href|default('#') }}"
+               class="button{% if item.button_style == 'secondary' %} button--secondary{% elif item.button_style == 'tertiary' %} button--tertiary{% elif item.button_style == 'simple' %} button--simple{% endif %}"
+               {% if item.link.open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %}
+               {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
+              {{ item.button_label }}
+            </a>
+          {% endfor %}
+        </div>
+      {% endif %}
+    </div>
+  </section>
+{% endif %}

--- a/hotwax-theme/modules/outline-card-list.module/fields.json
+++ b/hotwax-theme/modules/outline-card-list.module/fields.json
@@ -20,9 +20,9 @@
     "type": "text",
     "default": "Card title"
   }, {
-    "id": "body",
-    "name": "body",
-    "label": "Body",
+    "id": "description",
+    "name": "description",
+    "label": "Description",
     "required": false,
     "locked": false,
     "type": "richtext",
@@ -97,7 +97,7 @@
   "type": "group",
   "default": [ {
     "title": "Card title",
-    "body": "<p>Add supporting card copy.</p>",
+    "description": "<p>Add supporting card copy.</p>",
     "meta": "Optional meta text",
     "link_behavior": "none",
     "link_type": "link",
@@ -113,7 +113,7 @@
     "button_label": "Learn more"
   }, {
     "title": "Card title",
-    "body": "<p>Add supporting card copy.</p>",
+    "description": "<p>Add supporting card copy.</p>",
     "meta": "Optional meta text",
     "link_behavior": "none",
     "link_type": "link",

--- a/hotwax-theme/modules/outline-card-list.module/fields.json
+++ b/hotwax-theme/modules/outline-card-list.module/fields.json
@@ -1,0 +1,153 @@
+[ {
+  "id": "cards",
+  "name": "cards",
+  "label": "Cards",
+  "required": false,
+  "locked": false,
+  "occurrence": {
+    "min": 1,
+    "max": null,
+    "sorting_label_field": "title",
+    "default": 2
+  },
+  "children": [ {
+    "id": "title",
+    "name": "title",
+    "label": "Title",
+    "required": false,
+    "locked": false,
+    "allow_new_line": false,
+    "type": "text",
+    "default": "Card title"
+  }, {
+    "id": "body",
+    "name": "body",
+    "label": "Body",
+    "required": false,
+    "locked": false,
+    "type": "richtext",
+    "default": "<p>Add supporting card copy.</p>"
+  }, {
+    "id": "meta",
+    "name": "meta",
+    "label": "Meta text",
+    "required": false,
+    "locked": false,
+    "allow_new_line": false,
+    "type": "text",
+    "default": ""
+  }, {
+    "id": "link_behavior",
+    "name": "link_behavior",
+    "label": "Link behavior",
+    "required": false,
+    "locked": false,
+    "display": "select",
+    "choices": [ [ "none", "None" ], [ "card", "Full card" ], [ "button", "Button" ] ],
+    "multiple": false,
+    "type": "choice",
+    "default": "none"
+  }, {
+    "id": "link_type",
+    "name": "link_type",
+    "label": "Link type",
+    "required": false,
+    "locked": false,
+    "display": "select",
+    "choices": [ [ "link", "Link" ], [ "anchor", "Anchor" ] ],
+    "multiple": false,
+    "type": "choice",
+    "default": "link"
+  }, {
+    "id": "link",
+    "name": "link",
+    "label": "Link",
+    "required": false,
+    "locked": false,
+    "supported_types": [ "EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS", "BLOG" ],
+    "show_advanced_rel_options": false,
+    "type": "link",
+    "default": {
+      "url": {
+        "type": "EXTERNAL",
+        "href": ""
+      },
+      "open_in_new_tab": false,
+      "no_follow": false
+    }
+  }, {
+    "id": "anchor_target",
+    "name": "anchor_target",
+    "label": "Anchor target",
+    "required": false,
+    "locked": false,
+    "allow_new_line": false,
+    "type": "text",
+    "default": ""
+  }, {
+    "id": "button_label",
+    "name": "button_label",
+    "label": "Button label",
+    "required": false,
+    "locked": false,
+    "allow_new_line": false,
+    "type": "text",
+    "default": "Learn more"
+  } ],
+  "type": "group",
+  "default": [ {
+    "title": "Card title",
+    "body": "<p>Add supporting card copy.</p>",
+    "meta": "Optional meta text",
+    "link_behavior": "none",
+    "link_type": "link",
+    "link": {
+      "url": {
+        "type": "EXTERNAL",
+        "href": ""
+      },
+      "open_in_new_tab": false,
+      "no_follow": false
+    },
+    "anchor_target": "",
+    "button_label": "Learn more"
+  }, {
+    "title": "Card title",
+    "body": "<p>Add supporting card copy.</p>",
+    "meta": "Optional meta text",
+    "link_behavior": "none",
+    "link_type": "link",
+    "link": {
+      "url": {
+        "type": "EXTERNAL",
+        "href": ""
+      },
+      "open_in_new_tab": false,
+      "no_follow": false
+    },
+    "anchor_target": "",
+    "button_label": "Learn more"
+  } ]
+}, {
+  "id": "columns_desktop",
+  "name": "columns_desktop",
+  "label": "Desktop columns",
+  "required": false,
+  "locked": false,
+  "display": "select",
+  "choices": [ [ "1", "1" ], [ "2", "2" ], [ "3", "3" ] ],
+  "multiple": false,
+  "type": "choice",
+  "default": "2"
+}, {
+  "id": "columns_tablet",
+  "name": "columns_tablet",
+  "label": "Tablet columns",
+  "required": false,
+  "locked": false,
+  "display": "select",
+  "choices": [ [ "1", "1" ], [ "2", "2" ] ],
+  "multiple": false,
+  "type": "choice",
+  "default": "2"
+} ]

--- a/hotwax-theme/modules/outline-card-list.module/meta.json
+++ b/hotwax-theme/modules/outline-card-list.module/meta.json
@@ -1,0 +1,7 @@
+{
+  "global": false,
+  "content_types": [ "LANDING_PAGE", "SITE_PAGE" ],
+  "host_template_types": [ "PAGE" ],
+  "label": "Outline card list",
+  "is_available_for_new_content": true
+}

--- a/hotwax-theme/modules/outline-card-list.module/module.css
+++ b/hotwax-theme/modules/outline-card-list.module/module.css
@@ -1,17 +1,27 @@
 .outline-card-list {
   display: grid;
-  gap: var(--spacer-md);
+  gap: 32px;
   max-width: var(--content-width, 1200px);
   margin-inline: auto;
-  padding-inline: var(--spacer-md);
+  padding-inline: 0;
 }
 
 .outline-card-list__card.card {
+  background-color: #f4f4f4;
+  border: 1px solid #e2e2e2;
+  border-radius: 8px;
+  box-shadow: none;
   display: flex;
   flex-direction: column;
   height: 100%;
   margin: 0;
-  padding: var(--spacer-md);
+  padding: 32px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.outline-card-list__card.card:hover {
+  box-shadow: 0 4px 16px rgba(12, 12, 13, 0.08);
+  transform: none;
 }
 
 a.outline-card-list__card.card {
@@ -21,7 +31,36 @@ a.outline-card-list__card.card {
 .outline-card-list__title,
 .outline-card-list__body,
 .outline-card-list__meta {
-  margin-bottom: var(--spacer-sm);
+  margin-bottom: 18px;
+}
+
+.outline-card-list__title {
+  color: #2d2d2d;
+  font-family: "Open Sans", sans-serif;
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.outline-card-list__body {
+  color: #5f6368;
+  font-family: "Open Sans", sans-serif;
+  font-size: 16px;
+  line-height: 1.3;
+}
+
+.outline-card-list__body p {
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.outline-card-list__meta {
+  color: #2d2d2d;
+  font-family: "Open Sans", sans-serif;
+  font-size: 17px;
+  font-weight: 600;
+  line-height: 1.3;
 }
 
 .outline-card-list__body > *:last-child {
@@ -33,12 +72,16 @@ a.outline-card-list__card.card {
 }
 
 .outline-card-list__action {
-  margin-top: var(--spacer-md);
+  margin-top: 24px;
 }
 
 @media (max-width: 767px) {
   .outline-card-list {
     grid-template-columns: 1fr;
-    padding-inline: var(--spacer-sm);
+    padding-inline: 20px;
+  }
+
+  .outline-card-list__card.card {
+    padding: 24px;
   }
 }

--- a/hotwax-theme/modules/outline-card-list.module/module.css
+++ b/hotwax-theme/modules/outline-card-list.module/module.css
@@ -1,0 +1,44 @@
+.outline-card-list {
+  display: grid;
+  gap: var(--spacer-md);
+  max-width: var(--content-width, 1200px);
+  margin-inline: auto;
+  padding-inline: var(--spacer-md);
+}
+
+.outline-card-list__card.card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  margin: 0;
+  padding: var(--spacer-md);
+}
+
+a.outline-card-list__card.card {
+  text-decoration: none;
+}
+
+.outline-card-list__title,
+.outline-card-list__body,
+.outline-card-list__meta {
+  margin-bottom: var(--spacer-sm);
+}
+
+.outline-card-list__body > *:last-child {
+  margin-bottom: 0;
+}
+
+.outline-card-list__meta {
+  margin-top: auto;
+}
+
+.outline-card-list__action {
+  margin-top: var(--spacer-md);
+}
+
+@media (max-width: 767px) {
+  .outline-card-list {
+    grid-template-columns: 1fr;
+    padding-inline: var(--spacer-sm);
+  }
+}

--- a/hotwax-theme/modules/outline-card-list.module/module.css
+++ b/hotwax-theme/modules/outline-card-list.module/module.css
@@ -1,7 +1,7 @@
 .outline-card-list {
   display: grid;
   gap: 32px;
-  max-width: var(--content-width, 1200px);
+  max-width: var(--page-max-width, 1200px);
   margin-inline: auto;
   padding-inline: 0;
 }

--- a/hotwax-theme/modules/outline-card-list.module/module.html
+++ b/hotwax-theme/modules/outline-card-list.module/module.html
@@ -19,21 +19,23 @@
     {% if item.link_type == "anchor" %}
       {% set href = "#" ~ item.anchor_target %}
     {% else %}
-      {% set href = item.link.url.href %}
-      {% if item.link.url.type is equalto "EMAIL_ADDRESS" %}
+      {% set href = item.link.url.href if item.link and item.link.url else "" %}
+      {% if item.link and item.link.url and item.link.url.type is equalto "EMAIL_ADDRESS" %}
         {% set href = "mailto:" ~ href %}
       {% endif %}
     {% endif %}
-    {% set rel = (item.link.open_in_new_tab ? "noopener " : "") ~ (item.link.no_follow ? "nofollow" : "") %}
+    {% set open_in_new_tab = item.link.open_in_new_tab if item.link else false %}
+    {% set no_follow = item.link.no_follow if item.link else false %}
+    {% set rel = (open_in_new_tab ? "noopener " : "") ~ (no_follow ? "nofollow" : "") %}
 
     {% if item.link_behavior == "card" %}
-      <a class="outline-card-list__card card" href="{{ href|default('#') }}" {% if item.link.open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %} {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
+      <a class="outline-card-list__card card" href="{{ href|default('#') }}" {% if open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %} {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
     {% else %}
       <article class="outline-card-list__card card">
     {% endif %}
 
       {% if item.title %}
-        <h3 class="outline-card-list__title">{{ item.title }}</h3>
+        <h3 class="outline-card-list__title">{{ item.title|escape }}</h3>
       {% endif %}
 
       {% if item.description %}
@@ -43,13 +45,13 @@
       {% endif %}
 
       {% if item.meta %}
-        <p class="outline-card-list__meta">{{ item.meta }}</p>
+        <p class="outline-card-list__meta">{{ item.meta|escape }}</p>
       {% endif %}
 
       {% if item.link_behavior == "button" %}
         <div class="outline-card-list__action">
-          <a class="button button--secondary" href="{{ href|default('#') }}" {% if item.link.open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %} {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
-            {{ item.button_label }}
+          <a class="button button--secondary" href="{{ href|default('#') }}" {% if open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %} {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
+            {{ item.button_label|escape }}
           </a>
         </div>
       {% endif %}

--- a/hotwax-theme/modules/outline-card-list.module/module.html
+++ b/hotwax-theme/modules/outline-card-list.module/module.html
@@ -36,9 +36,9 @@
         <h3 class="outline-card-list__title">{{ item.title }}</h3>
       {% endif %}
 
-      {% if item.body %}
+      {% if item.description %}
         <div class="outline-card-list__body">
-          {{ item.body }}
+          {{ item.description }}
         </div>
       {% endif %}
 

--- a/hotwax-theme/modules/outline-card-list.module/module.html
+++ b/hotwax-theme/modules/outline-card-list.module/module.html
@@ -1,0 +1,63 @@
+{% require_css %}
+<style>
+  {% scope_css %}
+    .outline-card-list {
+      grid-template-columns: repeat({{ module.columns_desktop|default("2") }}, minmax(0, 1fr));
+    }
+
+    @media (max-width: 991px) {
+      .outline-card-list {
+        grid-template-columns: repeat({{ module.columns_tablet|default("2") }}, minmax(0, 1fr));
+      }
+    }
+  {% end_scope_css %}
+</style>
+{% end_require_css %}
+
+<div class="outline-card-list">
+  {% for item in module.cards %}
+    {% if item.link_type == "anchor" %}
+      {% set href = "#" ~ item.anchor_target %}
+    {% else %}
+      {% set href = item.link.url.href %}
+      {% if item.link.url.type is equalto "EMAIL_ADDRESS" %}
+        {% set href = "mailto:" ~ href %}
+      {% endif %}
+    {% endif %}
+    {% set rel = (item.link.open_in_new_tab ? "noopener " : "") ~ (item.link.no_follow ? "nofollow" : "") %}
+
+    {% if item.link_behavior == "card" %}
+      <a class="outline-card-list__card card" href="{{ href|default('#') }}" {% if item.link.open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %} {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
+    {% else %}
+      <article class="outline-card-list__card card">
+    {% endif %}
+
+      {% if item.title %}
+        <h3 class="outline-card-list__title">{{ item.title }}</h3>
+      {% endif %}
+
+      {% if item.body %}
+        <div class="outline-card-list__body">
+          {{ item.body }}
+        </div>
+      {% endif %}
+
+      {% if item.meta %}
+        <p class="outline-card-list__meta">{{ item.meta }}</p>
+      {% endif %}
+
+      {% if item.link_behavior == "button" %}
+        <div class="outline-card-list__action">
+          <a class="button button--secondary" href="{{ href|default('#') }}" {% if item.link.open_in_new_tab and item.link_type != "anchor" %}target="_blank"{% endif %} {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
+            {{ item.button_label }}
+          </a>
+        </div>
+      {% endif %}
+
+    {% if item.link_behavior == "card" %}
+      </a>
+    {% else %}
+      </article>
+    {% endif %}
+  {% endfor %}
+</div>

--- a/hotwax-theme/modules/pricing-card.module/fields.json
+++ b/hotwax-theme/modules/pricing-card.module/fields.json
@@ -1,0 +1,135 @@
+[ {
+  "id": "badge",
+  "name": "badge",
+  "label": "Badge",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": ""
+}, {
+  "id": "plan_name",
+  "name": "plan_name",
+  "label": "Plan name",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": "Plan name"
+}, {
+  "id": "price_prefix",
+  "name": "price_prefix",
+  "label": "Price prefix",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": "$"
+}, {
+  "id": "price",
+  "name": "price",
+  "label": "Price",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": "0"
+}, {
+  "id": "price_suffix",
+  "name": "price_suffix",
+  "label": "Price suffix",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": "/ mo"
+}, {
+  "id": "features",
+  "name": "features",
+  "label": "Features",
+  "required": false,
+  "locked": false,
+  "occurrence": {
+    "min": 0,
+    "max": null,
+    "sorting_label_field": "text",
+    "default": 4
+  },
+  "children": [ {
+    "id": "text",
+    "name": "text",
+    "label": "Text",
+    "required": false,
+    "locked": false,
+    "allow_new_line": false,
+    "type": "text",
+    "default": "Feature item"
+  } ],
+  "type": "group",
+  "default": [ {
+    "text": "Feature item"
+  }, {
+    "text": "Feature item"
+  }, {
+    "text": "Feature item"
+  }, {
+    "text": "Feature item"
+  } ]
+}, {
+  "id": "button_label",
+  "name": "button_label",
+  "label": "Button label",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": "Talk to sales"
+}, {
+  "id": "link_type",
+  "name": "link_type",
+  "label": "Link type",
+  "required": false,
+  "locked": false,
+  "display": "select",
+  "choices": [ [ "link", "Link" ], [ "anchor", "Anchor" ] ],
+  "multiple": false,
+  "type": "choice",
+  "default": "link"
+}, {
+  "id": "button_link",
+  "name": "button_link",
+  "label": "Button link",
+  "required": false,
+  "locked": false,
+  "supported_types": [ "EXTERNAL", "CONTENT", "FILE", "EMAIL_ADDRESS", "BLOG" ],
+  "show_advanced_rel_options": false,
+  "type": "link",
+  "default": {
+    "url": {
+      "type": "EXTERNAL",
+      "href": ""
+    },
+    "open_in_new_tab": false,
+    "no_follow": false
+  }
+}, {
+  "id": "anchor_target",
+  "name": "anchor_target",
+  "label": "Anchor target",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": ""
+}, {
+  "id": "button_style",
+  "name": "button_style",
+  "label": "Button style",
+  "required": false,
+  "locked": false,
+  "display": "select",
+  "choices": [ [ "primary", "Primary" ], [ "secondary", "Secondary" ], [ "simple", "Simple" ], [ "tertiary", "Tertiary" ] ],
+  "multiple": false,
+  "type": "choice",
+  "default": "primary"
+} ]

--- a/hotwax-theme/modules/pricing-card.module/meta.json
+++ b/hotwax-theme/modules/pricing-card.module/meta.json
@@ -1,0 +1,7 @@
+{
+  "global": false,
+  "content_types": [ "LANDING_PAGE", "SITE_PAGE" ],
+  "host_template_types": [ "PAGE" ],
+  "label": "Pricing card",
+  "is_available_for_new_content": true
+}

--- a/hotwax-theme/modules/pricing-card.module/module.css
+++ b/hotwax-theme/modules/pricing-card.module/module.css
@@ -1,10 +1,20 @@
 .pricing-card.card {
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 4px 4px -1px rgba(12, 12, 13, 0.1), 0 4px 4px -1px rgba(12, 12, 13, 0.05);
   display: flex;
   flex-direction: column;
   height: 100%;
   margin: 0;
-  padding: var(--spacer-lg);
+  min-height: 400px;
+  overflow: hidden;
+  padding: 32px;
   text-align: center;
+}
+
+.pricing-card.card:hover {
+  box-shadow: 0 4px 4px -1px rgba(12, 12, 13, 0.1), 0 4px 4px -1px rgba(12, 12, 13, 0.05);
+  transform: none;
 }
 
 .pricing-card__content {
@@ -16,26 +26,79 @@
 .pricing-card__badge,
 .pricing-card__name,
 .pricing-card__price {
-  margin-bottom: var(--spacer-sm);
+  margin-bottom: 16px;
+}
+
+.pricing-card__name {
+  color: #1e1e1e;
+  font-family: "Open Sans Condensed", "Open Sans", sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.48px;
+  line-height: 1.2;
+  margin-top: 0;
 }
 
 .pricing-card__price {
   align-items: baseline;
+  color: #1e1e1e;
   display: flex;
   justify-content: center;
+  line-height: 1;
+}
+
+.pricing-card__price-prefix {
+  font-family: "Open Sans Condensed", "Open Sans", sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.48px;
+}
+
+.pricing-card__price-value {
+  font-family: "Open Sans Condensed", "Open Sans", sans-serif;
+  font-size: 48px;
+  font-weight: 700;
+  letter-spacing: -0.96px;
+}
+
+.pricing-card__price-suffix {
+  font-family: "Montserrat", "Open Sans", sans-serif;
+  font-size: 14px;
+  line-height: 1.8;
 }
 
 .pricing-card__features {
-  margin-block: var(--spacer-md);
+  color: #757575;
+  font-family: "Montserrat", "Open Sans", sans-serif;
+  font-size: 16px;
+  line-height: 1.4;
+  margin-block: 0 24px;
+  padding-left: 24px;
   text-align: left;
 }
 
 .pricing-card__features li + li {
-  margin-top: var(--spacer-xs);
+  margin-top: 12px;
 }
 
 .pricing-card__button {
+  border-radius: 9999px;
+  box-shadow: none;
+  color: #ffffff !important;
   justify-content: center;
   margin-top: auto;
+  min-height: 45px;
+  padding: 8px 24px;
   width: 100%;
+}
+
+.pricing-card__button.button--secondary {
+  background-color: #ffffff;
+  color: #ec2227 !important;
+}
+
+@media (max-width: 767px) {
+  .pricing-card.card {
+    min-height: 0;
+  }
 }

--- a/hotwax-theme/modules/pricing-card.module/module.css
+++ b/hotwax-theme/modules/pricing-card.module/module.css
@@ -1,0 +1,41 @@
+.pricing-card.card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  margin: 0;
+  padding: var(--spacer-lg);
+  text-align: center;
+}
+
+.pricing-card__content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
+.pricing-card__badge,
+.pricing-card__name,
+.pricing-card__price {
+  margin-bottom: var(--spacer-sm);
+}
+
+.pricing-card__price {
+  align-items: baseline;
+  display: flex;
+  justify-content: center;
+}
+
+.pricing-card__features {
+  margin-block: var(--spacer-md);
+  text-align: left;
+}
+
+.pricing-card__features li + li {
+  margin-top: var(--spacer-xs);
+}
+
+.pricing-card__button {
+  justify-content: center;
+  margin-top: auto;
+  width: 100%;
+}

--- a/hotwax-theme/modules/pricing-card.module/module.html
+++ b/hotwax-theme/modules/pricing-card.module/module.html
@@ -1,0 +1,52 @@
+{% if module.link_type == "anchor" %}
+  {% set href = "#" ~ module.anchor_target %}
+{% else %}
+  {% set href = module.button_link.url.href %}
+  {% if module.button_link.url.type is equalto "EMAIL_ADDRESS" %}
+    {% set href = "mailto:" ~ href %}
+  {% endif %}
+{% endif %}
+{% set rel = (module.button_link.open_in_new_tab ? "noopener " : "") ~ (module.button_link.no_follow ? "nofollow" : "") %}
+
+<article class="pricing-card card">
+  <div class="pricing-card__content">
+    {% if module.badge %}
+      <p class="pricing-card__badge">{{ module.badge }}</p>
+    {% endif %}
+
+    {% if module.plan_name %}
+      <h3 class="pricing-card__name">{{ module.plan_name }}</h3>
+    {% endif %}
+
+    <div class="pricing-card__price">
+      {% if module.price_prefix %}
+        <span class="pricing-card__price-prefix">{{ module.price_prefix }}</span>
+      {% endif %}
+      {% if module.price %}
+        <span class="pricing-card__price-value">{{ module.price }}</span>
+      {% endif %}
+      {% if module.price_suffix %}
+        <span class="pricing-card__price-suffix">{{ module.price_suffix }}</span>
+      {% endif %}
+    </div>
+
+    {% if module.features %}
+      <ul class="pricing-card__features">
+        {% for item in module.features %}
+          {% if item.text %}
+            <li>{{ item.text }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
+
+  {% if module.button_label %}
+    <a href="{{ href|default('#') }}"
+       class="button pricing-card__button{% if module.button_style == 'secondary' %} button--secondary{% elif module.button_style == 'tertiary' %} button--tertiary{% elif module.button_style == 'simple' %} button--simple{% endif %}"
+       {% if module.button_link.open_in_new_tab and module.link_type != "anchor" %}target="_blank"{% endif %}
+       {% if rel|trim %}rel="{{ rel|trim }}"{% endif %}>
+      {{ module.button_label }}
+    </a>
+  {% endif %}
+</article>

--- a/hotwax-theme/modules/pricing-card.module/module.html
+++ b/hotwax-theme/modules/pricing-card.module/module.html
@@ -1,12 +1,14 @@
 {% if module.link_type == "anchor" %}
   {% set href = "#" ~ module.anchor_target %}
 {% else %}
-  {% set href = module.button_link.url.href %}
-  {% if module.button_link.url.type is equalto "EMAIL_ADDRESS" %}
+  {% set href = module.button_link.url.href if module.button_link and module.button_link.url else "" %}
+  {% if module.button_link and module.button_link.url and module.button_link.url.type is equalto "EMAIL_ADDRESS" %}
     {% set href = "mailto:" ~ href %}
   {% endif %}
 {% endif %}
-{% set rel = (module.button_link.open_in_new_tab ? "noopener " : "") ~ (module.button_link.no_follow ? "nofollow" : "") %}
+{% set open_in_new_tab = module.button_link.open_in_new_tab if module.button_link else false %}
+{% set no_follow = module.button_link.no_follow if module.button_link else false %}
+{% set rel = (open_in_new_tab ? "noopener " : "") ~ (no_follow ? "nofollow" : "") %}
 
 <article class="pricing-card card">
   <div class="pricing-card__content">

--- a/hotwax-theme/modules/section-header.module/fields.json
+++ b/hotwax-theme/modules/section-header.module/fields.json
@@ -1,0 +1,38 @@
+[ {
+  "id": "anchor_id",
+  "name": "anchor_id",
+  "label": "Anchor ID",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": ""
+}, {
+  "id": "title",
+  "name": "title",
+  "label": "Title",
+  "required": false,
+  "locked": false,
+  "allow_new_line": false,
+  "type": "text",
+  "default": "Section title"
+}, {
+  "id": "subtitle",
+  "name": "subtitle",
+  "label": "Subtitle",
+  "required": false,
+  "locked": false,
+  "type": "richtext",
+  "default": "<p>Add a short section subtitle.</p>"
+}, {
+  "id": "alignment",
+  "name": "alignment",
+  "label": "Alignment",
+  "required": false,
+  "locked": false,
+  "display": "select",
+  "choices": [ [ "left", "Left" ], [ "center", "Center" ] ],
+  "multiple": false,
+  "type": "choice",
+  "default": "left"
+} ]

--- a/hotwax-theme/modules/section-header.module/meta.json
+++ b/hotwax-theme/modules/section-header.module/meta.json
@@ -1,0 +1,7 @@
+{
+  "global": false,
+  "content_types": [ "LANDING_PAGE", "SITE_PAGE" ],
+  "host_template_types": [ "PAGE" ],
+  "label": "Section header",
+  "is_available_for_new_content": true
+}

--- a/hotwax-theme/modules/section-header.module/module.css
+++ b/hotwax-theme/modules/section-header.module/module.css
@@ -1,7 +1,7 @@
 .section-header {
   max-width: var(--content-width, 1200px);
   margin-inline: auto;
-  padding-inline: var(--spacer-md);
+  padding: 56px 0 24px;
 }
 
 .section-header--center {
@@ -9,7 +9,20 @@
 }
 
 .section-header__title {
-  margin-bottom: var(--spacer-sm);
+  color: #1e1e1e;
+  font-family: "Open Sans Condensed", "Open Sans", sans-serif;
+  font-size: 72px;
+  font-weight: 700;
+  letter-spacing: -2.16px;
+  line-height: 1.2;
+  margin: 0 0 8px;
+}
+
+.section-header__subtitle {
+  color: #757575;
+  font-family: "Montserrat", "Open Sans", sans-serif;
+  font-size: 32px;
+  line-height: 1.2;
 }
 
 .section-header__subtitle > *:last-child {
@@ -18,6 +31,15 @@
 
 @media (max-width: 767px) {
   .section-header {
-    padding-inline: var(--spacer-sm);
+    padding: 40px 20px 20px;
+  }
+
+  .section-header__title {
+    font-size: 42px;
+    letter-spacing: -1.26px;
+  }
+
+  .section-header__subtitle {
+    font-size: 22px;
   }
 }

--- a/hotwax-theme/modules/section-header.module/module.css
+++ b/hotwax-theme/modules/section-header.module/module.css
@@ -1,0 +1,23 @@
+.section-header {
+  max-width: var(--content-width, 1200px);
+  margin-inline: auto;
+  padding-inline: var(--spacer-md);
+}
+
+.section-header--center {
+  text-align: center;
+}
+
+.section-header__title {
+  margin-bottom: var(--spacer-sm);
+}
+
+.section-header__subtitle > *:last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 767px) {
+  .section-header {
+    padding-inline: var(--spacer-sm);
+  }
+}

--- a/hotwax-theme/modules/section-header.module/module.css
+++ b/hotwax-theme/modules/section-header.module/module.css
@@ -1,5 +1,5 @@
 .section-header {
-  max-width: var(--content-width, 1200px);
+  max-width: var(--page-max-width, 1200px);
   margin-inline: auto;
   padding: 56px 0 24px;
 }

--- a/hotwax-theme/modules/section-header.module/module.html
+++ b/hotwax-theme/modules/section-header.module/module.html
@@ -1,0 +1,11 @@
+<header class="section-header section-header--{{ module.alignment|default('left') }}"{% if module.anchor_id %} id="{{ module.anchor_id|escape_attr }}"{% endif %}>
+  {% if module.title %}
+    <h2 class="section-header__title">{{ module.title }}</h2>
+  {% endif %}
+
+  {% if module.subtitle %}
+    <div class="section-header__subtitle">
+      {{ module.subtitle }}
+    </div>
+  {% endif %}
+</header>

--- a/hotwax-theme/pricing-page-implementation-plan.md
+++ b/hotwax-theme/pricing-page-implementation-plan.md
@@ -1,0 +1,62 @@
+# Pricing Page Module Implementation Plan
+
+## Goal
+
+Build the pricing page as a template-level layout made from reusable HubSpot modules. The template should not own pricing content, plan data, CTA labels, card copy, or inline rich text anchors. Editors should be able to change page content later through module fields.
+
+The modules created for this work are generic page-building components, not pricing-page-only components, except for the single pricing card module.
+
+## Figma References
+
+- Hero/banner pattern: `3585:217`, `Hero / Text Title Hero + Native Button Group`
+- Outline card pattern: `3585:246`, `Path Card / Store Inventory Management`
+- Section header pattern: `3585:251`, `Text Content Title / Commerce OMS plans`
+- Pricing card pattern: `3585:255`, `Pricing Card / Starter`
+- Final CTA placement: `3585:565`, `Section / Final CTA`
+
+## Module Count
+
+Implement 4 reusable module types:
+
+1. `general-banner.module`
+2. `section-header.module`
+3. `outline-card-list.module`
+4. `pricing-card.module`
+
+Use existing button classes where possible. The pricing template is responsible for laying modules out into rows, columns, and repeated sections.
+
+## Template Layout
+
+1. Hero banner
+   - `general-banner.module`
+   - Full width
+
+2. Product path selector
+   - `section-header.module`
+   - `outline-card-list.module`
+
+3. First pricing group
+   - `section-header.module`
+   - Three separate `pricing-card.module` instances in a 3-column DnD row
+
+4. Second pricing group
+   - `section-header.module`
+   - Three separate `pricing-card.module` instances in a 3-column DnD row
+
+5. Detail section
+   - `section-header.module`
+   - `outline-card-list.module`
+
+6. Final CTA
+   - `general-banner.module`
+   - Same banner module as the page start, with subtitle optionally empty
+
+## Template Rules
+
+- Keep pricing data out of the template.
+- Keep CTA labels and links out of the template.
+- Keep card copy out of the template.
+- Do not use rich text spans for anchors.
+- Do not add pricing-specific layout logic inside generic modules.
+- Do not edit existing CSS files for this implementation.
+- New module CSS should be limited to layout, spacing, sizing, and responsive behavior.

--- a/hotwax-theme/templates/pricing-2026.html
+++ b/hotwax-theme/templates/pricing-2026.html
@@ -1,0 +1,116 @@
+<!--
+  templateType: page
+  isAvailableForNewContent: true
+  label: HotWax Theme - Pricing 2026
+-->
+{% extends "./layouts/base.html" %}
+
+{% block body %}
+  {% dnd_area "dnd_area" class="body-container", label="Pricing page" %}
+
+    {% dnd_section %}
+      {% dnd_column width=12 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/general-banner", label="Hero banner" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+    {% dnd_section %}
+      {% dnd_column width=12 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/section-header", label="Product path header" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/outline-card-list", label="Product path cards" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+    {% dnd_section %}
+      {% dnd_column width=12 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/section-header", label="First pricing group header" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+    {% dnd_section %}
+      {% dnd_column offset=0, width=4 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/pricing-card", label="First plan card" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+      {% dnd_column offset=4, width=4 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/pricing-card", label="Second plan card" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+      {% dnd_column offset=8, width=4 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/pricing-card", label="Third plan card" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+    {% dnd_section %}
+      {% dnd_column width=12 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/section-header", label="Second pricing group header" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+    {% dnd_section %}
+      {% dnd_column offset=0, width=4 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/pricing-card", label="Fourth plan card" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+      {% dnd_column offset=4, width=4 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/pricing-card", label="Fifth plan card" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+      {% dnd_column offset=8, width=4 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/pricing-card", label="Sixth plan card" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+    {% dnd_section %}
+      {% dnd_column width=12 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/section-header", label="Detail section header" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/outline-card-list", label="Detail cards" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+    {% dnd_section %}
+      {% dnd_column width=12 %}
+        {% dnd_row %}
+          {% dnd_module path="../modules/general-banner", label="Final CTA banner" %}
+          {% end_dnd_module %}
+        {% end_dnd_row %}
+      {% end_dnd_column %}
+    {% end_dnd_section %}
+
+  {% end_dnd_area %}
+{% endblock body %}

--- a/hotwax-theme/templates/pricing-2026.html
+++ b/hotwax-theme/templates/pricing-2026.html
@@ -11,7 +11,42 @@
     {% dnd_section %}
       {% dnd_column width=12 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/general-banner", label="Hero banner" %}
+          {% dnd_module
+            path="../modules/general-banner",
+            label="Hero banner",
+            show_banner=true,
+            title="HotWax Commerce pricing",
+            subtitle="Order management and store inventory plans for retail rollout stages",
+            description="<p>Start with the operating model you need today, then scale order volume, store coverage, integrations, and support without rebuilding your commerce operations stack.</p>",
+            buttons=[ {
+              "button_label": "Talk to sales",
+              "link_type": "link",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": "/contact-us/"
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "",
+              "button_style": "primary"
+            }, {
+              "button_label": "Compare plans",
+              "link_type": "anchor",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "pricing-paths",
+              "button_style": "secondary"
+            } ],
+            alignment="left"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
@@ -20,11 +55,56 @@
     {% dnd_section %}
       {% dnd_column width=12 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/section-header", label="Product path header" %}
+          {% dnd_module
+            path="../modules/section-header",
+            label="Product path header",
+            anchor_id="pricing-paths",
+            title="Choose your pricing path",
+            subtitle="<p>Start with the product suite that matches your operating model.</p>",
+            alignment="left"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
         {% dnd_row %}
-          {% dnd_module path="../modules/outline-card-list", label="Product path cards" %}
+          {% dnd_module
+            path="../modules/outline-card-list",
+            label="Product path cards",
+            columns_desktop="2",
+            columns_tablet="2",
+            cards=[ {
+              "title": "Commerce OMS",
+              "description": "<p>For retailers orchestrating ecommerce, store fulfillment, pre-orders, routing, and inventory availability from a central OMS.</p>",
+              "meta": "Starts at $1,000/mo",
+              "link_behavior": "card",
+              "link_type": "anchor",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "commerce-oms-plans",
+              "button_label": "View OMS plans"
+            }, {
+              "title": "Store Inventory Management",
+              "description": "<p>For teams rolling out transfer orders, receiving, cycle counts, returns lookup, and store-level inventory controls.</p>",
+              "meta": "Starts at $100/mo",
+              "link_behavior": "card",
+              "link_type": "anchor",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "store-inventory-plans",
+              "button_label": "View store plans"
+            } ]
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
@@ -33,7 +113,14 @@
     {% dnd_section %}
       {% dnd_column width=12 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/section-header", label="First pricing group header" %}
+          {% dnd_module
+            path="../modules/section-header",
+            label="Commerce OMS plans header",
+            anchor_id="commerce-oms-plans",
+            title="Omnichannel OMS plans",
+            subtitle="<p>Included order volume and retail location coverage.</p>",
+            alignment="left"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
@@ -42,19 +129,100 @@
     {% dnd_section %}
       {% dnd_column offset=0, width=4 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/pricing-card", label="First plan card" %}
+          {% dnd_module
+            path="../modules/pricing-card",
+            label="OMS Starter plan",
+            plan_name="Starter",
+            price_prefix="$",
+            price="1,000",
+            price_suffix="/ mo",
+            features=[ {
+              "text": "Up to 1,000 monthly orders"
+            }, {
+              "text": "$0.75 per additional order"
+            }, {
+              "text": "Up to 10 retail locations"
+            }, {
+              "text": "BOPIS, ship from store, store inventory, and pre-orders"
+            } ],
+            button_label="Talk to sales",
+            link_type="link",
+            button_link={
+              "url": {
+                "type": "EXTERNAL",
+                "href": "/contact-us/"
+              },
+              "open_in_new_tab": false,
+              "no_follow": false
+            },
+            button_style="primary"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
       {% dnd_column offset=4, width=4 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/pricing-card", label="Second plan card" %}
+          {% dnd_module
+            path="../modules/pricing-card",
+            label="OMS Professional plan",
+            plan_name="Professional",
+            price_prefix="$",
+            price="2,500",
+            price_suffix="/ mo",
+            features=[ {
+              "text": "Up to 5,000 monthly orders"
+            }, {
+              "text": "$0.50 per additional order"
+            }, {
+              "text": "Up to 20 retail locations"
+            }, {
+              "text": "Includes native reports and broader support coverage"
+            } ],
+            button_label="Talk to sales",
+            link_type="link",
+            button_link={
+              "url": {
+                "type": "EXTERNAL",
+                "href": "/contact-us/"
+              },
+              "open_in_new_tab": false,
+              "no_follow": false
+            },
+            button_style="primary"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
       {% dnd_column offset=8, width=4 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/pricing-card", label="Third plan card" %}
+          {% dnd_module
+            path="../modules/pricing-card",
+            label="OMS Enterprise plan",
+            plan_name="Enterprise",
+            price_prefix="$",
+            price="10,000",
+            price_suffix="/ mo",
+            features=[ {
+              "text": "Up to 20,000 monthly orders"
+            }, {
+              "text": "$0.50 per additional order"
+            }, {
+              "text": "Up to 500 retail locations"
+            }, {
+              "text": "Includes sales audit and external reporting database access"
+            } ],
+            button_label="Talk to sales",
+            link_type="link",
+            button_link={
+              "url": {
+                "type": "EXTERNAL",
+                "href": "/contact-us/"
+              },
+              "open_in_new_tab": false,
+              "no_follow": false
+            },
+            button_style="primary"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
@@ -63,7 +231,14 @@
     {% dnd_section %}
       {% dnd_column width=12 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/section-header", label="Second pricing group header" %}
+          {% dnd_module
+            path="../modules/section-header",
+            label="Store Inventory Management plans header",
+            anchor_id="store-inventory-plans",
+            title="Store Inventory Management plans",
+            subtitle="<p>Flat per-store pricing with no transaction limits and no per-user fees.</p>",
+            alignment="left"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
@@ -72,19 +247,100 @@
     {% dnd_section %}
       {% dnd_column offset=0, width=4 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/pricing-card", label="Fourth plan card" %}
+          {% dnd_module
+            path="../modules/pricing-card",
+            label="Store Starter plan",
+            plan_name="Starter",
+            price_prefix="$",
+            price="100",
+            price_suffix="/ mo",
+            features=[ {
+              "text": "Up to 5 retail locations"
+            }, {
+              "text": "Transfer orders, receiving, and cycle counting"
+            }, {
+              "text": "Shopify integration"
+            }, {
+              "text": "FedEx shipping integration"
+            } ],
+            button_label="Talk to sales",
+            link_type="link",
+            button_link={
+              "url": {
+                "type": "EXTERNAL",
+                "href": "/contact-us/"
+              },
+              "open_in_new_tab": false,
+              "no_follow": false
+            },
+            button_style="primary"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
       {% dnd_column offset=4, width=4 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/pricing-card", label="Fifth plan card" %}
+          {% dnd_module
+            path="../modules/pricing-card",
+            label="Store Professional plan",
+            plan_name="Professional",
+            price_prefix="$",
+            price="2,500",
+            price_suffix="/ mo",
+            features=[ {
+              "text": "Up to 20 retail locations"
+            }, {
+              "text": "$80 per additional store"
+            }, {
+              "text": "Returns lookup, restocking, PO receiving, and custom permissions"
+            }, {
+              "text": "Shopify, POS embedded, NetSuite, UPS, FedEx, and ShipStation"
+            } ],
+            button_label="Talk to sales",
+            link_type="link",
+            button_link={
+              "url": {
+                "type": "EXTERNAL",
+                "href": "/contact-us/"
+              },
+              "open_in_new_tab": false,
+              "no_follow": false
+            },
+            button_style="primary"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
       {% dnd_column offset=8, width=4 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/pricing-card", label="Sixth plan card" %}
+          {% dnd_module
+            path="../modules/pricing-card",
+            label="Store Enterprise plan",
+            plan_name="Enterprise",
+            price_prefix="$",
+            price="8,000",
+            price_suffix="/ mo",
+            features=[ {
+              "text": "Up to 100 retail locations"
+            }, {
+              "text": "$50 per additional store"
+            }, {
+              "text": "Enterprise store operations workflows and support"
+            }, {
+              "text": "Advanced NetSuite and shipping integration coverage"
+            } ],
+            button_label="Talk to sales",
+            link_type="link",
+            button_link={
+              "url": {
+                "type": "EXTERNAL",
+                "href": "/contact-us/"
+              },
+              "open_in_new_tab": false,
+              "no_follow": false
+            },
+            button_style="primary"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
@@ -93,11 +349,88 @@
     {% dnd_section %}
       {% dnd_column width=12 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/section-header", label="Detail section header" %}
+          {% dnd_module
+            path="../modules/section-header",
+            label="Detail section header",
+            anchor_id="pricing-tier-details",
+            title="What changes by tier",
+            subtitle="<p>Use these editable detail cards to explain implementation, reporting, add-ons, and support differences.</p>",
+            alignment="left"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
         {% dnd_row %}
-          {% dnd_module path="../modules/outline-card-list", label="Detail cards" %}
+          {% dnd_module
+            path="../modules/outline-card-list",
+            label="Detail cards",
+            columns_desktop="2",
+            columns_tablet="2",
+            cards=[ {
+              "title": "Implementation and go-live",
+              "description": "<p>Store Inventory Management is designed for a focused Shopify and NetSuite rollout in about two weeks. OMS implementation depends on order routing rules, fulfillment workflows, integrations, and rollout scope.</p>",
+              "meta": "",
+              "link_behavior": "none",
+              "link_type": "link",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "",
+              "button_label": ""
+            }, {
+              "title": "Reporting and data access",
+              "description": "<p>Commerce OMS includes native reports in Professional and Enterprise. Starter can add native reports, while Professional can add external reporting database read access. Enterprise includes external reporting database access.</p>",
+              "meta": "",
+              "link_behavior": "none",
+              "link_type": "link",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "",
+              "button_label": ""
+            }, {
+              "title": "Sales audit and advanced operations",
+              "description": "<p>Retail sales audit is included in Commerce OMS Enterprise and available as an add-on for Professional. Custom BI, extra integrations, and advanced enterprise workflows are scoped based on implementation needs.</p>",
+              "meta": "",
+              "link_behavior": "none",
+              "link_type": "link",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "",
+              "button_label": ""
+            }, {
+              "title": "Support",
+              "description": "<p>Support scales with plan complexity. Starter is built for lighter rollout needs, Professional adds broader operational coverage, and Enterprise is intended for larger retail networks with higher-touch support requirements.</p>",
+              "meta": "",
+              "link_behavior": "none",
+              "link_type": "link",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "",
+              "button_label": ""
+            } ]
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}
@@ -106,7 +439,42 @@
     {% dnd_section %}
       {% dnd_column width=12 %}
         {% dnd_row %}
-          {% dnd_module path="../modules/general-banner", label="Final CTA banner" %}
+          {% dnd_module
+            path="../modules/general-banner",
+            label="Final CTA banner",
+            show_banner=true,
+            title="Ready to model pricing for your rollout?",
+            subtitle="",
+            description="<p>Share your monthly order volume, store count, ecommerce platform, ERP, POS, shipping providers, and reporting needs. HotWax can map the right plan and add-ons before the page becomes a checkout flow.</p>",
+            buttons=[ {
+              "button_label": "Talk to sales",
+              "link_type": "link",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": "/contact-us/"
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "",
+              "button_style": "primary"
+            }, {
+              "button_label": "Review tier details",
+              "link_type": "anchor",
+              "link": {
+                "url": {
+                  "type": "EXTERNAL",
+                  "href": ""
+                },
+                "open_in_new_tab": false,
+                "no_follow": false
+              },
+              "anchor_target": "pricing-tier-details",
+              "button_style": "secondary"
+            } ],
+            alignment="left"
+          %}
           {% end_dnd_module %}
         {% end_dnd_row %}
       {% end_dnd_column %}


### PR DESCRIPTION
## Business summary
HotWax needs a pricing page that can become the start of a conversion journey without making marketing depend on custom template rendering logic. This PR introduces reusable HubSpot page-building modules and a module-based pricing template so pricing sections, CTAs, card copy, and detail blocks can be edited through module fields in HubSpot.

Closes #85

## What changed
- Added a reusable general banner module for hero and final CTA placements.
- Added a reusable section header module with optional subtitle and anchor support.
- Added a reusable outline card list module for product-path and detail-card sections.
- Added a single pricing card module that editors can place into template-controlled columns.
- Added a `pricing-2026.html` template that composes those modules into the pricing journey.
- Preconfigured the pricing template defaults with the current draft page content so the unpublished HubSpot page renders the real pricing draft immediately.
- Polished the new module CSS to more closely match the Figma components: hero typography, section headers, outline cards, pricing card shadows/radius, price hierarchy, and button colors.
- Added an implementation note documenting the module boundaries and layout plan.

## HubSpot draft update
- Uploaded the new modules and updated pricing template to `hc-github-prod` / `6357099`.
- Published only the Design Manager assets required for preview rendering; the `/pricing` website page itself remains a draft.
- Verified draft page `364433312496` still has `state: DRAFT` and `templatePath: hotwax-theme/templates/pricing-2026.html`.
- Verified the preview HTML now includes `general-banner`, `outline-card-list`, and `pricing-card`, and no longer includes the old `cards-no-animation` or `section-title-wrapper` markers.
- Verified button labels render with the Figma-like white/red treatment instead of inheriting black theme text.

## Implementation notes
- Existing theme modules and existing CSS files were left untouched.
- The new module CSS now intentionally carries the visual component styling from Figma.
- The template composes editable module instances; content is exposed through module fields for page-editor updates.

## Validation
- `jq empty` on all new module `fields.json` and `meta.json` files.
- `hs cms lint hotwax-theme/modules/general-banner.module` passed with 0 issues.
- `hs cms lint hotwax-theme/modules/section-header.module` passed with 0 issues.
- `hs cms lint hotwax-theme/modules/outline-card-list.module` passed with 0 issues.
- `hs cms lint hotwax-theme/modules/pricing-card.module` passed with 0 issues.
- `hs cms lint hotwax-theme/templates/pricing-2026.html` passed with 0 issues.
- Headless Chrome preview check confirmed the expected new module markers and button colors on the HubSpot draft preview.

## Known validation note
- Theme-wide `hs lint hotwax-theme` is not clean on `main`; it reports existing `hotwax-theme/css/main.css` `color()` resolution errors and then hits a HubSpot rate limit. Targeted lint for the new files passes.
