### PR TITLE
SEO: preload blog hero image and drop lazy load (PM-314)

### DIFF
--- a/hotwax-theme/templates/blog-post.html
+++ b/hotwax-theme/templates/blog-post.html
@@ -7,6 +7,11 @@
 {% extends "./layouts/base.html" %}
 
 {% block body %}
+  {% require_head %}
+    {% if content.featured_image %}
+      <link rel="preload" as="image" href="{{ content.featured_image }}" fetchpriority="high">
+    {% endif %}
+  {% end_require_head %}
   <div class="blog-post mt-4">
     <div class="container">
       <div class="blog-post__time col-md-12 px-0 mb-3 px-md-2">
@@ -33,7 +38,7 @@
             </div>
             <div class="col-md-6">
               <img class="blog-post__featured-image" src="{{ content.featured_image }}"
-                alt="{{ content.featured_image_alt_text }}" loading="lazy" width="900">
+                alt="{{ content.featured_image_alt_text }}" width="900" fetchpriority="high" decoding="async">
             </div>
           </div>
           <div class="row px-md-3 py-4 py-md-4 justify-content-center">

--- a/hotwax-theme/templates/blog-post.html
+++ b/hotwax-theme/templates/blog-post.html
@@ -9,7 +9,7 @@
 {% block body %}
   {% require_head %}
     {% if content.featured_image %}
-      <link rel="preload" as="image" href="{{ content.featured_image }}" fetchpriority="high">
+      <link rel="preload" as="image" href="{{ content.featured_image|resize_image_url(900) }}" fetchpriority="high">
     {% endif %}
   {% end_require_head %}
   <div class="blog-post mt-4">
@@ -37,8 +37,8 @@
               </div>
             </div>
             <div class="col-md-6">
-              <img class="blog-post__featured-image" src="{{ content.featured_image }}"
-                alt="{{ content.featured_image_alt_text }}" width="900" fetchpriority="high" decoding="async">
+              <img class="blog-post__featured-image" src="{{ content.featured_image|resize_image_url(900) }}"
+                alt="{{ content.featured_image_alt_text }}" width="900" fetchpriority="high">
             </div>
           </div>
           <div class="row px-md-3 py-4 py-md-4 justify-content-center">


### PR DESCRIPTION
## What
The blog post template loaded its hero (featured) image with `loading="lazy"`, so the browser found it late and it became a slow LCP on every blog post. Mobile lab LCP measured around 7s with "LCP image discovery failed, the image is lazy-loaded".

## Change (`hotwax-theme/templates/blog-post.html`)
- Remove `loading="lazy"` from the hero image so it loads eagerly
- Add `fetchpriority="high"` and `decoding="async"` to the hero image
- Preload the featured image in the head (guarded by `{% if content.featured_image %}`)

No visual or layout change. Markup and styling are untouched otherwise.

## Why not the CLS part yet
PM-314 also mentions layout shifts. Reserving space needs a known aspect ratio, and blog featured images vary in ratio, so forcing a height could distort them. That is a separate, careful follow-up so this PR stays safe and non-distorting.

## How this reaches production
Merging to `main` does not deploy on its own. The `hubspot_prod.yml` workflow deploys the theme to HubSpot on a published GitHub Release. So: you merge, then a release is cut to deploy.

Jira: PM-314