### PR TITLE
Add AI vibes use case calculator module

### DIFF
--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/fields.json
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/fields.json
@@ -1,0 +1,208 @@
+[ {
+  "id" : "heading",
+  "name" : "heading",
+  "label" : "Heading",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : null,
+  "default" : "Build the inventory quantity shoppers can trust"
+}, {
+  "id" : "description",
+  "name" : "description",
+  "label" : "Description",
+  "required" : false,
+  "locked" : false,
+  "type" : "richtext",
+  "display_width" : null,
+  "default" : "<p>Start with network stock, apply the rules that prevent risky promises, and publish an Online ATP quantity that stores can actually fulfill.</p>"
+}, {
+  "id" : "calculation_title",
+  "name" : "calculation_title",
+  "label" : "Calculation title",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : null,
+  "default" : "Online availability calculation"
+}, {
+  "id" : "product_label",
+  "name" : "product_label",
+  "label" : "Product label",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : "half_width",
+  "default" : "Product stock"
+}, {
+  "id" : "product_copy",
+  "name" : "product_copy",
+  "label" : "Product copy",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : "half_width",
+  "default" : "Units available for this SKU"
+}, {
+  "id" : "product_stock",
+  "name" : "product_stock",
+  "label" : "Product stock count",
+  "required" : false,
+  "locked" : false,
+  "type" : "number",
+  "display_width" : "half_width",
+  "default" : 84
+}, {
+  "id" : "mobile_title",
+  "name" : "mobile_title",
+  "label" : "Mobile product title",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : "half_width",
+  "default" : "Build Online ATP for this SKU"
+}, {
+  "id" : "result_label",
+  "name" : "result_label",
+  "label" : "Result label",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : "half_width",
+  "default" : "Available after this rule"
+}, {
+  "id" : "result_copy",
+  "name" : "result_copy",
+  "label" : "Result copy",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : "half_width",
+  "default" : "Sellable quantity after selected guardrails"
+}, {
+  "id" : "guardrails",
+  "name" : "guardrails",
+  "label" : "Guardrails",
+  "required" : false,
+  "locked" : false,
+  "occurrence" : {
+    "min" : 1,
+    "max" : 6,
+    "sorting_label_field" : "label",
+    "default" : 4
+  },
+  "children" : [ {
+    "id" : "label",
+    "name" : "label",
+    "label" : "Label",
+    "required" : false,
+    "locked" : false,
+    "allow_new_line" : false,
+    "type" : "text",
+    "display_width" : "half_width",
+    "default" : "Store safety stock"
+  }, {
+    "id" : "row_copy",
+    "name" : "row_copy",
+    "label" : "Row copy",
+    "required" : false,
+    "locked" : false,
+    "allow_new_line" : false,
+    "type" : "text",
+    "display_width" : "half_width",
+    "default" : "Hold the last units stores need locally"
+  }, {
+    "id" : "amount",
+    "name" : "amount",
+    "label" : "Amount deducted",
+    "required" : false,
+    "locked" : false,
+    "type" : "number",
+    "display_width" : "half_width",
+    "default" : 4
+  }, {
+    "id" : "running_label",
+    "name" : "running_label",
+    "label" : "Running label",
+    "required" : false,
+    "locked" : false,
+    "allow_new_line" : false,
+    "type" : "text",
+    "display_width" : "half_width",
+    "default" : "Safety stock applied"
+  }, {
+    "id" : "chip",
+    "name" : "chip",
+    "label" : "Chip",
+    "required" : false,
+    "locked" : false,
+    "allow_new_line" : false,
+    "type" : "text",
+    "display_width" : "half_width",
+    "default" : "Store safety stock"
+  }, {
+    "id" : "detail_title",
+    "name" : "detail_title",
+    "label" : "Detail title",
+    "required" : false,
+    "locked" : false,
+    "allow_new_line" : false,
+    "type" : "text",
+    "display_width" : "half_width",
+    "default" : "Protect the last local units"
+  }, {
+    "id" : "detail_copy",
+    "name" : "detail_copy",
+    "label" : "Detail copy",
+    "required" : false,
+    "locked" : false,
+    "type" : "textarea",
+    "display_width" : null,
+    "default" : "Safety stock holds back 4 units for store demand while the rest of this SKU can still be made available online."
+  } ],
+  "tab" : "CONTENT",
+  "expanded" : false,
+  "group_occurrence_meta" : null,
+  "type" : "group",
+  "display_width" : null,
+  "default" : [ {
+    "label" : "Store safety stock",
+    "row_copy" : "Hold the last units stores need locally",
+    "amount" : 4,
+    "running_label" : "Safety stock applied",
+    "chip" : "Store safety stock",
+    "detail_title" : "Protect the last local units",
+    "detail_copy" : "Safety stock holds back 4 units for store demand while the rest of this SKU can still be made available online."
+  }, {
+    "label" : "Company threshold",
+    "row_copy" : "Company-wide buffer to protect from oversell",
+    "amount" : 2,
+    "running_label" : "Safety stock and threshold",
+    "chip" : "Company threshold",
+    "detail_title" : "Add a small channel buffer",
+    "detail_copy" : "A company-wide buffer protects this SKU from overselling when online demand moves faster than inventory updates."
+  }, {
+    "label" : "Reserved stock",
+    "row_copy" : "Deduct units already promised",
+    "amount" : 18,
+    "running_label" : "Reservations included",
+    "chip" : "Reserved stock",
+    "detail_title" : "Do not sell the same unit twice",
+    "detail_copy" : "Reserved stock removes units already assigned to orders, pickup requests, pre-orders, backorders, or transfers before availability is published."
+  }, {
+    "label" : "Paused fulfillment",
+    "row_copy" : "Hold inventory from locations temporarily offline",
+    "amount" : 14,
+    "running_label" : "All guardrails applied",
+    "chip" : "Paused fulfillment",
+    "detail_title" : "Pause risky fulfillment locations",
+    "detail_copy" : "When a store or warehouse is temporarily offline, its inventory can stay out of Online ATP until the location is ready to fulfill again."
+  } ]
+} ]

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/fields.json
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/fields.json
@@ -48,6 +48,16 @@
   "display_width" : "half_width",
   "default" : "Units available for this SKU"
 }, {
+  "id" : "running_guardrails_copy",
+  "name" : "running_guardrails_copy",
+  "label" : "Running guardrails copy",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : "half_width",
+  "default" : "Running guardrails for this SKU"
+}, {
   "id" : "product_stock",
   "name" : "product_stock",
   "label" : "Product stock count",
@@ -66,6 +76,16 @@
   "type" : "text",
   "display_width" : "half_width",
   "default" : "Build Online ATP for this SKU"
+}, {
+  "id" : "product_availability_label",
+  "name" : "product_availability_label",
+  "label" : "Product availability label",
+  "required" : false,
+  "locked" : false,
+  "allow_new_line" : false,
+  "type" : "text",
+  "display_width" : "half_width",
+  "default" : "Product availability"
 }, {
   "id" : "result_label",
   "name" : "result_label",

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/meta.json
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/meta.json
@@ -1,0 +1,7 @@
+{
+  "global" : false,
+  "content_types" : [ "LANDING_PAGE", "SITE_PAGE" ],
+  "host_template_types" : [ "PAGE" ],
+  "label" : "HW Use Case Calculator",
+  "is_available_for_new_content" : true
+}

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.css
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.css
@@ -1,0 +1,463 @@
+.hw-online-atp-builder {
+  color: var(--color-text-body);
+  font-family: var(--font-family-body, sans-serif);
+  margin-inline: auto;
+  max-width: var(--page-max-width);
+  width: 100%;
+}
+
+.hw-online-atp-builder,
+.hw-online-atp-builder *,
+.hw-online-atp-builder *::before,
+.hw-online-atp-builder *::after {
+  box-sizing: border-box;
+}
+
+.hw-online-atp-builder__intro {
+  align-items: end;
+  display: grid;
+  gap: var(--spacer-lg);
+  grid-template-columns: minmax(0, 0.9fr) minmax(20rem, 1.1fr);
+  margin-block-end: var(--spacer-lg);
+}
+
+.hw-online-atp-builder__heading {
+  color: var(--color-text-title);
+  font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+  font-size: clamp(2.25rem, 5vw, 4rem);
+  font-weight: var(--font-weight-extrabold);
+  letter-spacing: 0;
+  line-height: 1.08;
+  margin: 0;
+}
+
+.hw-online-atp-builder__description,
+.hw-online-atp-builder__description p {
+  color: var(--color-text-body);
+  font-size: 1rem;
+  line-height: 1.65;
+  margin: 0;
+}
+
+.hw-online-atp-builder__calculator {
+  background: #fff;
+  border: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+  border-radius: 8px;
+  box-shadow: var(--m-shadow);
+  min-height: 532px;
+  overflow: hidden;
+}
+
+.hw-online-atp-builder__bar {
+  align-items: center;
+  background: color-mix(in srgb, var(--color-text-body) 4%, #fff);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+  color: var(--color-text-title);
+  display: flex;
+  font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+  font-size: 0.9rem;
+  font-weight: var(--font-weight-extrabold);
+  min-height: 52px;
+  padding-inline: var(--spacer-md);
+}
+
+.hw-online-atp-builder__equation {
+  align-items: stretch;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 150px minmax(0, 1fr) 28px minmax(0, 1fr) 28px minmax(0, 1fr);
+  padding: 22px var(--spacer-md);
+}
+
+.hw-online-atp-builder__product-icon,
+.hw-online-atp-builder__metric {
+  border: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+  border-radius: 8px;
+  min-height: 124px;
+}
+
+.hw-online-atp-builder__product-icon {
+  background: radial-gradient(circle at 30% 20%, color-mix(in srgb, var(--color-primary) 12%, transparent), transparent 34%), #fff;
+  display: grid;
+  place-items: center;
+}
+
+.hw-online-atp-builder__shirt-icon {
+  color: var(--color-primary);
+  filter: drop-shadow(0 14px 18px rgba(18, 18, 18, 0.12));
+  height: 84px;
+  transform: rotate(-12deg);
+  width: 84px;
+}
+
+.hw-online-atp-builder__metric {
+  align-content: space-between;
+  background: #fff;
+  display: grid;
+  gap: var(--spacer-sm);
+  padding: 18px;
+}
+
+.hw-online-atp-builder__metric--deduct {
+  background: color-mix(in srgb, var(--color-primary) 4%, #fff);
+  border-color: color-mix(in srgb, var(--color-primary) 26%, #fff);
+}
+
+.hw-online-atp-builder__metric--result {
+  background: #202124;
+  border-color: #202124;
+  color: #fff;
+}
+
+.hw-online-atp-builder__label small,
+.hw-online-atp-builder__row-copy small,
+.hw-online-atp-builder__receipt-top small {
+  color: color-mix(in srgb, var(--color-text-body) 70%, #fff);
+  display: block;
+  font-size: 0.68rem;
+  font-weight: var(--font-weight-extrabold);
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  margin-block-end: 7px;
+  text-transform: uppercase;
+}
+
+.hw-online-atp-builder__metric--result .hw-online-atp-builder__label small {
+  color: color-mix(in srgb, #fff 82%, transparent);
+}
+
+.hw-online-atp-builder__label strong {
+  color: inherit;
+  display: block;
+  font-size: 0.88rem;
+  font-weight: var(--font-weight-extrabold);
+  line-height: 1.35;
+  min-height: 38px;
+}
+
+.hw-online-atp-builder__value {
+  color: var(--color-text-title);
+  font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+  font-size: 2.15rem;
+  font-weight: var(--font-weight-extrabold);
+  line-height: 1;
+}
+
+.hw-online-atp-builder__metric--deduct .hw-online-atp-builder__value,
+.hw-online-atp-builder__row-value {
+  color: var(--color-primary);
+}
+
+.hw-online-atp-builder__metric--result .hw-online-atp-builder__value {
+  color: #fff;
+}
+
+.hw-online-atp-builder__symbol {
+  align-items: center;
+  color: color-mix(in srgb, var(--color-text-body) 70%, #fff);
+  display: flex;
+  font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+  font-size: 1.4rem;
+  font-weight: var(--font-weight-extrabold);
+  justify-content: center;
+}
+
+.hw-online-atp-builder__receipt {
+  display: none;
+}
+
+.hw-online-atp-builder__body {
+  align-items: stretch;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  padding: 22px var(--spacer-md) var(--spacer-md);
+}
+
+.hw-online-atp-builder__stack {
+  background: color-mix(in srgb, var(--color-text-body) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+  border-radius: 8px;
+  display: grid;
+  grid-auto-rows: 1fr;
+  height: 238px;
+  overflow: hidden;
+}
+
+.hw-online-atp-builder__row {
+  align-items: center;
+  background: #fff;
+  border: 0;
+  color: var(--color-text-title);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 12px;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  padding-inline: var(--spacer-md);
+  text-align: left;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.hw-online-atp-builder__row + .hw-online-atp-builder__row {
+  border-top: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+}
+
+.hw-online-atp-builder__row:hover,
+.hw-online-atp-builder__row:focus-visible,
+.hw-online-atp-builder__row.is-active {
+  background: color-mix(in srgb, var(--color-primary) 4%, #fff);
+}
+
+.hw-online-atp-builder__row:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+
+.hw-online-atp-builder__row.is-applied {
+  background: color-mix(in srgb, var(--color-primary) 2%, #fff);
+}
+
+.hw-online-atp-builder__check {
+  align-items: center;
+  background: color-mix(in srgb, var(--color-text-body) 8%, #fff);
+  border-radius: 50%;
+  color: color-mix(in srgb, var(--color-text-body) 78%, #fff);
+  display: inline-flex;
+  height: 24px;
+  justify-content: center;
+  width: 24px;
+}
+
+.hw-online-atp-builder__check svg {
+  height: 15px;
+  width: 15px;
+}
+
+.hw-online-atp-builder__row.is-active .hw-online-atp-builder__check {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.hw-online-atp-builder__row.is-applied:not(.is-active) .hw-online-atp-builder__check {
+  background: color-mix(in srgb, var(--color-primary) 16%, #fff);
+  color: var(--color-primary);
+}
+
+.hw-online-atp-builder__row-copy strong {
+  display: block;
+  font-size: 0.84rem;
+  font-weight: var(--font-weight-extrabold);
+  line-height: 1.25;
+}
+
+.hw-online-atp-builder__row-value {
+  font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+  font-size: 1.35rem;
+  font-weight: var(--font-weight-extrabold);
+  line-height: 1;
+  min-width: 60px;
+  text-align: right;
+}
+
+.hw-online-atp-builder__detail {
+  background: color-mix(in srgb, var(--color-text-body) 3%, #fff);
+  border: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+  border-radius: 8px;
+  display: grid;
+  gap: 10px;
+  grid-template-rows: auto 1fr;
+  height: 238px;
+  padding: 20px;
+}
+
+.hw-online-atp-builder__chip {
+  align-items: center;
+  align-self: start;
+  background: color-mix(in srgb, var(--color-primary) 4%, #fff);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 24%, #fff);
+  border-radius: 999px;
+  color: var(--color-primary);
+  display: inline-flex;
+  font-size: 0.66rem;
+  font-weight: var(--font-weight-extrabold);
+  justify-content: center;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  min-height: 28px;
+  padding-inline: 10px;
+  text-transform: uppercase;
+  white-space: nowrap;
+  width: max-content;
+}
+
+.hw-online-atp-builder__detail h3 {
+  color: var(--color-text-title);
+  font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+  font-size: 1.28rem;
+  font-weight: var(--font-weight-extrabold);
+  letter-spacing: 0;
+  line-height: 1.22;
+  margin-block: 0 8px;
+  min-height: 44px;
+}
+
+.hw-online-atp-builder__detail p {
+  color: var(--color-text-body);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0;
+  min-height: 78px;
+}
+
+@media (max-width: 991px) {
+  .hw-online-atp-builder__intro {
+    align-items: start;
+    grid-template-columns: 1fr;
+  }
+
+  .hw-online-atp-builder__body {
+    grid-template-columns: 1fr;
+  }
+
+  .hw-online-atp-builder__detail {
+    height: 220px;
+  }
+}
+
+@media (max-width: 700px) {
+  .hw-online-atp-builder__heading {
+    font-size: clamp(2.2rem, 12vw, 3.25rem);
+  }
+
+  .hw-online-atp-builder__calculator {
+    min-height: 972px;
+  }
+
+  .hw-online-atp-builder__bar {
+    min-height: 52px;
+  }
+
+  .hw-online-atp-builder__equation {
+    display: none;
+  }
+
+  .hw-online-atp-builder__receipt {
+    border-bottom: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+    display: grid;
+    gap: 14px;
+    padding: var(--spacer-md);
+  }
+
+  .hw-online-atp-builder__receipt-top {
+    align-items: center;
+    display: grid;
+    gap: 14px;
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+
+  .hw-online-atp-builder__receipt-top .hw-online-atp-builder__product-icon {
+    min-height: 72px;
+  }
+
+  .hw-online-atp-builder__receipt-top .hw-online-atp-builder__shirt-icon {
+    height: 54px;
+    width: 54px;
+  }
+
+  .hw-online-atp-builder__receipt-top strong {
+    color: var(--color-text-title);
+    display: block;
+    font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+    font-size: 1.12rem;
+    font-weight: var(--font-weight-extrabold);
+    line-height: 1.18;
+  }
+
+  .hw-online-atp-builder__receipt-lines {
+    background: #fff;
+    border: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .hw-online-atp-builder__receipt-line {
+    align-items: center;
+    border-bottom: 1px solid color-mix(in srgb, var(--color-text-body) 18%, transparent);
+    display: flex;
+    gap: var(--spacer-md);
+    justify-content: space-between;
+    min-height: 48px;
+    padding-inline: 14px;
+  }
+
+  .hw-online-atp-builder__receipt-line:last-child {
+    border-bottom: 0;
+  }
+
+  .hw-online-atp-builder__receipt-line span {
+    color: var(--color-text-body);
+    font-size: 0.86rem;
+    font-weight: var(--font-weight-bold);
+  }
+
+  .hw-online-atp-builder__receipt-line b {
+    color: var(--color-text-title);
+    font-family: var(--font-family-special, var(--font-family-body, sans-serif));
+    font-size: 1.42rem;
+    font-weight: var(--font-weight-extrabold);
+    line-height: 1;
+  }
+
+  .hw-online-atp-builder__receipt-line--deduct b {
+    color: var(--color-primary);
+  }
+
+  .hw-online-atp-builder__receipt-line--result {
+    background: #202124;
+  }
+
+  .hw-online-atp-builder__receipt-line--result span,
+  .hw-online-atp-builder__receipt-line--result b {
+    color: #fff;
+  }
+
+  .hw-online-atp-builder__body {
+    gap: var(--spacer-md);
+    padding: var(--spacer-md);
+  }
+
+  .hw-online-atp-builder__stack {
+    height: auto;
+  }
+
+  .hw-online-atp-builder__row {
+    gap: 10px;
+    grid-template-columns: 32px minmax(0, 1fr) auto;
+    min-height: 82px;
+    padding: 12px;
+  }
+
+  .hw-online-atp-builder__row-value {
+    font-size: 1.25rem;
+    min-width: 56px;
+  }
+
+  .hw-online-atp-builder__detail {
+    height: 238px;
+  }
+
+  .hw-online-atp-builder__detail h3,
+  .hw-online-atp-builder__detail p {
+    min-height: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hw-online-atp-builder *,
+  .hw-online-atp-builder *::before,
+  .hw-online-atp-builder *::after {
+    transition-duration: 0.01ms;
+  }
+}

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.css
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.css
@@ -181,7 +181,6 @@
   border-radius: 8px;
   display: grid;
   grid-auto-rows: 1fr;
-  height: 238px;
   overflow: hidden;
 }
 
@@ -195,6 +194,8 @@
   font: inherit;
   gap: 12px;
   grid-template-columns: 34px minmax(0, 1fr) auto;
+  min-height: 60px;
+  padding-block: 10px;
   padding-inline: var(--spacer-md);
   text-align: left;
   transition: background 0.2s ease, color 0.2s ease;
@@ -268,7 +269,7 @@
   display: grid;
   gap: 10px;
   grid-template-rows: auto 1fr;
-  height: 238px;
+  min-height: 238px;
   padding: 20px;
 }
 
@@ -322,7 +323,7 @@
   }
 
   .hw-online-atp-builder__detail {
-    height: 220px;
+    min-height: 220px;
   }
 }
 
@@ -430,6 +431,7 @@
 
   .hw-online-atp-builder__stack {
     height: auto;
+    min-height: 0;
   }
 
   .hw-online-atp-builder__row {
@@ -445,7 +447,7 @@
   }
 
   .hw-online-atp-builder__detail {
-    height: 238px;
+    min-height: 238px;
   }
 
   .hw-online-atp-builder__detail h3,

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.html
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.html
@@ -1,6 +1,13 @@
-{% set first_guardrail = module.guardrails[0] %}
+{% set first_guardrail = module.guardrails|first %}
 {% set product_stock = module.product_stock|default(84) %}
-{% set first_amount = first_guardrail.amount|default(0) %}
+{% set first_amount = 0 %}
+{% if first_guardrail %}
+  {% set first_amount = first_guardrail.amount|default(0)|abs %}
+{% endif %}
+{% set first_available = product_stock - first_amount %}
+{% if first_available < 0 %}
+  {% set first_available = 0 %}
+{% endif %}
 
 <section class="hw-online-atp-builder" data-hw-atp-builder data-stock="{{ product_stock|escape_attr }}">
   {% if module.heading or module.description %}
@@ -17,6 +24,7 @@
     </div>
   {% endif %}
 
+  {% if first_guardrail %}
   <div class="hw-online-atp-builder__calculator">
     {% if module.calculation_title %}
       <div class="hw-online-atp-builder__bar">
@@ -45,7 +53,7 @@
       <div class="hw-online-atp-builder__metric hw-online-atp-builder__metric--deduct">
         <span class="hw-online-atp-builder__label">
           <small data-hw-atp-running-label>{{ first_guardrail.running_label|default("Safety stock applied")|escape_html }}</small>
-          <strong>Running guardrails for this SKU</strong>
+          <strong>{{ module.running_guardrails_copy|default("Running guardrails for this SKU")|escape_html }}</strong>
         </span>
         <span class="hw-online-atp-builder__value" data-hw-atp-running-value>{{ first_amount }}</span>
       </div>
@@ -57,7 +65,7 @@
           <small data-hw-atp-result-label>{{ module.result_label|default("Available after this rule")|escape_html }}</small>
           <strong>{{ module.result_copy|default("Sellable quantity after selected guardrails")|escape_html }}</strong>
         </span>
-        <span class="hw-online-atp-builder__value" data-hw-atp-result-value>{{ product_stock - first_amount }}</span>
+        <span class="hw-online-atp-builder__value" data-hw-atp-result-value>{{ first_available }}</span>
       </div>
     </div>
 
@@ -70,7 +78,7 @@
           </svg>
         </div>
         <div>
-          <small>Product availability</small>
+          <small>{{ module.product_availability_label|default("Product availability")|escape_html }}</small>
           <strong>{{ module.mobile_title|default("Build Online ATP for this SKU")|escape_html }}</strong>
         </div>
       </div>
@@ -86,7 +94,7 @@
         </div>
         <div class="hw-online-atp-builder__receipt-line hw-online-atp-builder__receipt-line--result">
           <span data-hw-atp-mobile-result-label>{{ module.result_label|default("Available after this rule")|escape_html }}</span>
-          <b data-hw-atp-mobile-result-value>{{ product_stock - first_amount }}</b>
+          <b data-hw-atp-mobile-result-value>{{ first_available }}</b>
         </div>
       </div>
     </div>
@@ -98,7 +106,7 @@
             class="hw-online-atp-builder__row{% if loop.first %} is-active is-applied{% endif %}"
             type="button"
             data-hw-atp-row
-            data-amount="{{ item.amount|default(0)|escape_attr }}"
+            data-amount="{{ item.amount|default(0)|abs|escape_attr }}"
             data-running-label="{{ item.running_label|default(item.label)|escape_attr }}"
             data-chip="{{ item.chip|default(item.label)|escape_attr }}"
             data-title="{{ item.detail_title|escape_attr }}"
@@ -114,7 +122,7 @@
               <small>{{ item.label|escape_html }}</small>
               <strong>{{ item.row_copy|escape_html }}</strong>
             </span>
-            <span class="hw-online-atp-builder__row-value">-{{ item.amount|default(0) }}</span>
+            <span class="hw-online-atp-builder__row-value">-{{ item.amount|default(0)|abs }}</span>
           </button>
         {% endfor %}
       </div>
@@ -128,4 +136,5 @@
       </div>
     </div>
   </div>
+  {% endif %}
 </section>

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.html
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.html
@@ -1,0 +1,131 @@
+{% set first_guardrail = module.guardrails[0] %}
+{% set product_stock = module.product_stock|default(84) %}
+{% set first_amount = first_guardrail.amount|default(0) %}
+
+<section class="hw-online-atp-builder" data-hw-atp-builder data-stock="{{ product_stock|escape_attr }}">
+  {% if module.heading or module.description %}
+    <div class="hw-online-atp-builder__intro">
+      {% if module.heading %}
+        <h2 class="hw-online-atp-builder__heading">{{ module.heading|escape_html }}</h2>
+      {% endif %}
+
+      {% if module.description %}
+        <div class="hw-online-atp-builder__description">
+          {{ module.description }}
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <div class="hw-online-atp-builder__calculator">
+    {% if module.calculation_title %}
+      <div class="hw-online-atp-builder__bar">
+        <span>{{ module.calculation_title|escape_html }}</span>
+      </div>
+    {% endif %}
+
+    <div class="hw-online-atp-builder__equation" aria-label="Online ATP calculation">
+      <div class="hw-online-atp-builder__product-icon" aria-hidden="true">
+        <svg viewBox="0 0 512 512" class="hw-online-atp-builder__shirt-icon" role="img" focusable="false">
+          <path d="M314.56 48s-22.78 8-58.56 8-58.56-8-58.56-8a31.94 31.94 0 0 0-10.57 1.8L85.65 86.09a16 16 0 0 0-9.34 20.72l26.12 68.89a16 16 0 0 0 20.24 9.47l24.79-8.38a8 8 0 0 1 10.56 7.59V432a32 32 0 0 0 32 32h131.96a32 32 0 0 0 32-32V184.38a8 8 0 0 1 10.56-7.59l24.79 8.38a16 16 0 0 0 20.24-9.47l26.12-68.89a16 16 0 0 0-9.34-20.72L324.13 49.8A31.94 31.94 0 0 0 314.56 48Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+          <path d="M201.6 52.8a67.51 67.51 0 0 0 108.8 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+        </svg>
+      </div>
+
+      <div class="hw-online-atp-builder__metric">
+        <span class="hw-online-atp-builder__label">
+          <small>{{ module.product_label|default("Product stock")|escape_html }}</small>
+          <strong>{{ module.product_copy|default("Units available for this SKU")|escape_html }}</strong>
+        </span>
+        <span class="hw-online-atp-builder__value">{{ product_stock }}</span>
+      </div>
+
+      <span class="hw-online-atp-builder__symbol" aria-hidden="true">-</span>
+
+      <div class="hw-online-atp-builder__metric hw-online-atp-builder__metric--deduct">
+        <span class="hw-online-atp-builder__label">
+          <small data-hw-atp-running-label>{{ first_guardrail.running_label|default("Safety stock applied")|escape_html }}</small>
+          <strong>Running guardrails for this SKU</strong>
+        </span>
+        <span class="hw-online-atp-builder__value" data-hw-atp-running-value>{{ first_amount }}</span>
+      </div>
+
+      <span class="hw-online-atp-builder__symbol" aria-hidden="true">=</span>
+
+      <div class="hw-online-atp-builder__metric hw-online-atp-builder__metric--result">
+        <span class="hw-online-atp-builder__label">
+          <small data-hw-atp-result-label>{{ module.result_label|default("Available after this rule")|escape_html }}</small>
+          <strong>{{ module.result_copy|default("Sellable quantity after selected guardrails")|escape_html }}</strong>
+        </span>
+        <span class="hw-online-atp-builder__value" data-hw-atp-result-value>{{ product_stock - first_amount }}</span>
+      </div>
+    </div>
+
+    <div class="hw-online-atp-builder__receipt" aria-label="Mobile Online ATP calculation">
+      <div class="hw-online-atp-builder__receipt-top">
+        <div class="hw-online-atp-builder__product-icon" aria-hidden="true">
+          <svg viewBox="0 0 512 512" class="hw-online-atp-builder__shirt-icon" role="img" focusable="false">
+            <path d="M314.56 48s-22.78 8-58.56 8-58.56-8-58.56-8a31.94 31.94 0 0 0-10.57 1.8L85.65 86.09a16 16 0 0 0-9.34 20.72l26.12 68.89a16 16 0 0 0 20.24 9.47l24.79-8.38a8 8 0 0 1 10.56 7.59V432a32 32 0 0 0 32 32h131.96a32 32 0 0 0 32-32V184.38a8 8 0 0 1 10.56-7.59l24.79 8.38a16 16 0 0 0 20.24-9.47l26.12-68.89a16 16 0 0 0-9.34-20.72L324.13 49.8A31.94 31.94 0 0 0 314.56 48Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+            <path d="M201.6 52.8a67.51 67.51 0 0 0 108.8 0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="32"/>
+          </svg>
+        </div>
+        <div>
+          <small>Product availability</small>
+          <strong>{{ module.mobile_title|default("Build Online ATP for this SKU")|escape_html }}</strong>
+        </div>
+      </div>
+
+      <div class="hw-online-atp-builder__receipt-lines">
+        <div class="hw-online-atp-builder__receipt-line">
+          <span>{{ module.product_label|default("Product stock")|escape_html }}</span>
+          <b>{{ product_stock }}</b>
+        </div>
+        <div class="hw-online-atp-builder__receipt-line hw-online-atp-builder__receipt-line--deduct">
+          <span data-hw-atp-mobile-running-label>{{ first_guardrail.running_label|default("Safety stock applied")|escape_html }}</span>
+          <b>-<span data-hw-atp-mobile-running-value>{{ first_amount }}</span></b>
+        </div>
+        <div class="hw-online-atp-builder__receipt-line hw-online-atp-builder__receipt-line--result">
+          <span data-hw-atp-mobile-result-label>{{ module.result_label|default("Available after this rule")|escape_html }}</span>
+          <b data-hw-atp-mobile-result-value>{{ product_stock - first_amount }}</b>
+        </div>
+      </div>
+    </div>
+
+    <div class="hw-online-atp-builder__body">
+      <div class="hw-online-atp-builder__stack" aria-label="Availability guardrails">
+        {% for item in module.guardrails %}
+          <button
+            class="hw-online-atp-builder__row{% if loop.first %} is-active is-applied{% endif %}"
+            type="button"
+            data-hw-atp-row
+            data-amount="{{ item.amount|default(0)|escape_attr }}"
+            data-running-label="{{ item.running_label|default(item.label)|escape_attr }}"
+            data-chip="{{ item.chip|default(item.label)|escape_attr }}"
+            data-title="{{ item.detail_title|escape_attr }}"
+            data-copy="{{ item.detail_copy|escape_attr }}"
+            aria-pressed="{% if loop.first %}true{% else %}false{% endif %}"
+          >
+            <span class="hw-online-atp-builder__check" aria-hidden="true">
+              <svg viewBox="0 0 512 512" role="img" focusable="false">
+                <path d="M416 128 192 384l-96-96" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="44"/>
+              </svg>
+            </span>
+            <span class="hw-online-atp-builder__row-copy">
+              <small>{{ item.label|escape_html }}</small>
+              <strong>{{ item.row_copy|escape_html }}</strong>
+            </span>
+            <span class="hw-online-atp-builder__row-value">-{{ item.amount|default(0) }}</span>
+          </button>
+        {% endfor %}
+      </div>
+
+      <div class="hw-online-atp-builder__detail" aria-live="polite">
+        <span class="hw-online-atp-builder__chip" data-hw-atp-chip>{{ first_guardrail.chip|default(first_guardrail.label)|escape_html }}</span>
+        <div>
+          <h3 data-hw-atp-title>{{ first_guardrail.detail_title|escape_html }}</h3>
+          <p data-hw-atp-copy>{{ first_guardrail.detail_copy|escape_html }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.js
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.js
@@ -1,4 +1,6 @@
 (function () {
+  "use strict";
+
   const modules = document.querySelectorAll("[data-hw-atp-builder]");
 
   modules.forEach((moduleElement) => {
@@ -31,7 +33,7 @@
     const activateRow = (activeIndex) => {
       const activeRow = rows[activeIndex];
       const runningAmount = getRunningAmount(activeIndex);
-      const resultAmount = stock - runningAmount;
+      const resultAmount = Math.max(0, stock - runningAmount);
 
       rows.forEach((row, index) => {
         const isActive = index === activeIndex;

--- a/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.js
+++ b/hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.js
@@ -1,0 +1,60 @@
+(function () {
+  const modules = document.querySelectorAll("[data-hw-atp-builder]");
+
+  modules.forEach((moduleElement) => {
+    const stock = Number(moduleElement.dataset.stock) || 0;
+    const rows = Array.from(moduleElement.querySelectorAll("[data-hw-atp-row]"));
+
+    if (!rows.length) {
+      return;
+    }
+
+    const runningLabel = moduleElement.querySelector("[data-hw-atp-running-label]");
+    const runningValue = moduleElement.querySelector("[data-hw-atp-running-value]");
+    const resultValue = moduleElement.querySelector("[data-hw-atp-result-value]");
+    const mobileRunningLabel = moduleElement.querySelector("[data-hw-atp-mobile-running-label]");
+    const mobileRunningValue = moduleElement.querySelector("[data-hw-atp-mobile-running-value]");
+    const mobileResultValue = moduleElement.querySelector("[data-hw-atp-mobile-result-value]");
+    const chip = moduleElement.querySelector("[data-hw-atp-chip]");
+    const title = moduleElement.querySelector("[data-hw-atp-title]");
+    const copy = moduleElement.querySelector("[data-hw-atp-copy]");
+
+    const getAmount = (row) => Math.abs(Number(row.dataset.amount) || 0);
+    const getRunningAmount = (index) => rows.slice(0, index + 1).reduce((sum, row) => sum + getAmount(row), 0);
+
+    const setText = (target, value) => {
+      if (target) {
+        target.textContent = value;
+      }
+    };
+
+    const activateRow = (activeIndex) => {
+      const activeRow = rows[activeIndex];
+      const runningAmount = getRunningAmount(activeIndex);
+      const resultAmount = stock - runningAmount;
+
+      rows.forEach((row, index) => {
+        const isActive = index === activeIndex;
+        row.classList.toggle("is-active", isActive);
+        row.classList.toggle("is-applied", index <= activeIndex);
+        row.setAttribute("aria-pressed", isActive ? "true" : "false");
+      });
+
+      setText(runningLabel, activeRow.dataset.runningLabel || "");
+      setText(runningValue, runningAmount);
+      setText(resultValue, resultAmount);
+      setText(mobileRunningLabel, activeRow.dataset.runningLabel || "");
+      setText(mobileRunningValue, runningAmount);
+      setText(mobileResultValue, resultAmount);
+      setText(chip, activeRow.dataset.chip || "");
+      setText(title, activeRow.dataset.title || "");
+      setText(copy, activeRow.dataset.copy || "");
+    };
+
+    rows.forEach((row, index) => {
+      row.addEventListener("click", () => activateRow(index));
+    });
+
+    activateRow(0);
+  });
+})();


### PR DESCRIPTION
## Summary
- Adds a reusable AI-vibe use case calculator module for landing and site pages
- Keeps the module inside hotwax-theme/modules/ai-vibes
- Uses scoped CSS, vanilla JS, inline SVG icons, and editable guardrail fields

## Checks
- hs cms lint hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module
- git diff --name-status upstream/main...origin/codex/use-case-calculator-module confirms only the new module files are included
- node --check hotwax-theme/modules/ai-vibes/hw-use-case-calculator.module/module.js
- python3 -m json.tool on fields.json and meta.json