### PR TITLE
PM-314: make the blog hero eager and high priority for LCP (replaces #87)

### DIFF
--- a/hotwax-theme/templates/blog-post.html
+++ b/hotwax-theme/templates/blog-post.html
@@ -33,7 +33,7 @@
             </div>
             <div class="col-md-6">
               <img class="blog-post__featured-image" src="{{ content.featured_image }}"
-                alt="{{ content.featured_image_alt_text }}" loading="lazy" width="900">
+                alt="{{ content.featured_image_alt_text }}" width="900" fetchpriority="high">
             </div>
           </div>
           <div class="row px-md-3 py-4 py-md-4 justify-content-center">


### PR DESCRIPTION
Replaces #87. Same ticket ([PM-314](https://hotwax-team.atlassian.net/browse/PM-314)), corrected approach, one line.

## What this changes

`hotwax-theme/templates/blog-post.html`, the blog post hero:

```diff
-  alt="{{ content.featured_image_alt_text }}" loading="lazy" width="900">
+  alt="{{ content.featured_image_alt_text }}" width="900" fetchpriority="high">
```

That is the whole diff.

## Why

The hero is the LCP element on every blog post and it was set to `loading="lazy"`, so the browser discovered it late. Mobile LCP measured around 7 seconds. Removing the lazy attribute is the change that moves the metric, and `fetchpriority="high"` puts the hero at the front of the fetch queue.

## Why there is no preload here, and no resize_image_url

PR #87 tried to preload the hero, and the reviewer bot correctly pointed out that the preload URL and the img URL have to match or the image downloads twice. Both of those turned out to be dead ends on this template, and both are worth recording so nobody retries them.

**The preload cannot hold.** HubSpot generates a six candidate `srcset` plus a `sizes` attribute on this image on its own. Verified on the [live blog post](https://www.hotwax.co/blog/how-to-choose-oms-intelligent-routing), which renders `srcset` candidates at 450w, 900w, 1350w, 1800w, 2250w and 2700w with `sizes="(max-width: 900px) 100vw, 900px"`. The `width` attribute is the trigger, per [HubSpot's automatic image resizing docs](https://knowledge.hubspot.com/files/automatic-image-resizing-on-hubspot-content) and [this community thread](https://community.hubspot.com/t5/CMS-Development/Avoid-auto-generating-srcset-after-filling-img-width-amp-height/m-p/697269). A preload pinned to one URL only matches where the browser picks that exact candidate:

| Device | Slot | Device px needed | Candidate picked | Preload of 900w |
| --- | --- | --- | --- | --- |
| Desktop, DPR 1 | 900px | 900 | 900w | matches |
| Desktop, DPR 2 | 900px | 1800 | 1800w | misses, 71 KB wasted then 149 KB fetched |
| Phone 390px, DPR 3 | 390px | 1170 | 1350w | misses |

Only DPR 1 desktop wins. Everywhere else the preload downloads a file the browser never uses, competing for bandwidth during the LCP window. That is the same double download the review set out to remove, arriving through `srcset` instead of `src`.

**An already resized `src` does not suppress the `srcset`.** Checked every image on two live pages whose `src` already carries an explicit `?width=` and which also has a `width` attribute: 38 of 38 on the homepage and 5 of 5 on a blog post still received a generated `srcset`. So matching the preload to the img could not have fixed the double download regardless of syntax.

**And the syntax on #87 is invalid.** That branch carries `{{ content.featured_image|resize_image_url(900) }}` on both the preload and the img. `resize_image_url` is a HubL [function](https://developers.hubspot.com/docs/reference/cms/hubl/functions), not a filter, and it does not appear in the [filters reference](https://developers.hubspot.com/docs/reference/cms/hubl/filters) at all. The piped form has no filter to bind to, so it resolves to nothing and would ship an empty `src` on every blog post. That is worse than the problem it was written to fix, and it fails silently.

Leaving HubSpot's `srcset` alone means every device keeps getting a right sized hero, which is better than pinning one hardcoded width.

## What is still open

- **CLS.** The layout shift half of PM-314 is not addressed here. Blog featured image ratios vary, so a hardcoded height would distort images. It needs its own approach.
- **A preload that actually holds** would need a hand authored `srcset` with matching `imagesrcset` and `imagesizes`. Real work with its own testing, and it belongs in a separate ticket rather than bolted onto this one.

## Reviewer notes

- Template only. No visual or layout change, and no HubL that can fail to resolve.
- Please close #87 in favour of this one. I did not close it myself.
- Merging does not deploy. The `hubspot_prod.yml` workflow ships the theme when a GitHub Release is published, so the path is merge, then cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PM-314]: https://hotwax-team.atlassian.net/browse/PM-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ