### PR TITLE
PM-357: deduplicate legacy head output in base.html

### DIFF
--- a/hotwax-theme/templates/layouts/base.html
+++ b/hotwax-theme/templates/layouts/base.html
@@ -20,7 +20,6 @@
     {{ standard_header_includes }}
 
     {{ require_css(get_asset_url("/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css")) }}
-    {{ user_head_overrides }}
   </head>
   <body>
     {% block header %}

--- a/hotwax-theme/templates/layouts/base.html
+++ b/hotwax-theme/templates/layouts/base.html
@@ -19,7 +19,11 @@
     
     {{ standard_header_includes }}
     
-    {{ required_head_tags }}
+    {# PM-357: do not add required_head_tags here. It emits the same required head payload as
+       standard_header_includes above, so having both rendered the canonical tag, the Open Graph and
+       Twitter tags, the domain level head HTML, the page level head HTML (including JSON-LD), and the
+       inlined stylesheet twice in the head of every page built on this layout. standard_header_includes
+       is the documented variable and already covers all of it. #}
     {{ require_css(get_asset_url("/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css")) }}
     {{ user_head_overrides }}
   </head>

--- a/hotwax-theme/templates/layouts/base.html
+++ b/hotwax-theme/templates/layouts/base.html
@@ -18,12 +18,7 @@
     {% endif %}
     
     {{ standard_header_includes }}
-    
-    {# PM-357: do not add required_head_tags here. It emits the same required head payload as
-       standard_header_includes above, so having both rendered the canonical tag, the Open Graph and
-       Twitter tags, the domain level head HTML, the page level head HTML (including JSON-LD), and the
-       inlined stylesheet twice in the head of every page built on this layout. standard_header_includes
-       is the documented variable and already covers all of it. #}
+
     {{ require_css(get_asset_url("/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css")) }}
     {{ user_head_overrides }}
   </head>


### PR DESCRIPTION
Fixes [PM-357](https://hotwax-team.atlassian.net/browse/PM-357) and resolves the shared-layout portion of [PM-352](https://hotwax-team.atlassian.net/browse/PM-352).

## What changed

`hotwax-theme/templates/layouts/base.html` now keeps only HubSpot’s documented required include pair:

- `{{ standard_header_includes }}` in `<head>`
- `{{ standard_footer_includes }}` before `</body>`

The two undocumented legacy variables were removed:

- `{{ required_head_tags }}`
- `{{ user_head_overrides }}`

No CSS, JavaScript, module, partial, page template, or footer behavior was changed.

## Root cause

The original layout emitted the same head data through three variables. The live deployment was used to isolate them in two steps:

1. Removing `required_head_tags` reduced duplicate viewport, canonical, Open Graph, and stylesheet output from two copies to one, but page-authored Head HTML such as JSON-LD and keywords still appeared twice.
2. The remaining second copy appeared at the exact template position of `user_head_overrides`. On representative pages, every element it emitted was byte-identical to content already present earlier through `standard_header_includes`.
3. Removing `user_head_overrides` reduced the remaining JSON-LD and keyword duplicates to one while preserving all required metadata and styles.

HubSpot documents `standard_header_includes` as the required variable that supplies page metadata, attached stylesheets, and code configured at the domain, template, and page level. The two removed variables are undocumented legacy output paths.

Reference: https://developers.hubspot.com/docs/cms/reference/hubl/variables

## Live before and after

| Page | Item | Before | After |
|---|---|---:|---:|
| Homepage | viewport / canonical / `og:url` | 2 each | 1 each |
| Homepage | WebSite JSON-LD / keywords | 2 each | 1 each |
| OMS product page | viewport / canonical / `og:url` | 2 each | 1 each |
| OMS product page | Article JSON-LD / keywords | 2 each | 1 each |
| BOPIS solution page | viewport / canonical / `og:url` | 2 each | 1 each |
| BOPIS solution page | SoftwareApplication JSON-LD | 2 | 1 |

The BOPIS page has no keywords tag configured, so its expected count remains zero.

## HubSpot verification

The final `base.html` was uploaded as a single published file and fetched back from HubSpot. The fetched file is an exact byte match with local.

Validated live pages:

- https://www.hotwax.co/
- https://www.hotwax.co/product/omnichannel-order-management-system/
- https://www.hotwax.co/solution/buy-online-pick-up-in-store-bopis-software/

For all three pages:

- HTTP content rendered with the expected title, H1, and substantive body copy.
- Exactly one viewport, canonical, `og:url`, and JSON-LD block remained.
- `template_main.min.css`, Font Awesome, and `template_Hotwax_Stylesheet_2021.min.css` each remained present exactly once.
- Desktop and 390px mobile layouts rendered normally.
- No horizontal overflow was introduced.
- No browser console errors were reported.

## Safety

This removes duplicate output at the owning layout instead of deleting JSON-LD or metadata from individual HubSpot page settings. The authoritative editor-authored Head HTML remains delivered once through `standard_header_includes`.

`standard_footer_includes` is untouched, so HubSpot footer scripts and tracking behavior remain registered through the documented path.

## Scope

`base.html` is extended by the main site, landing, blog, product update, and system templates. This PR fixes pages using that shared layout.

The following legacy templates have separate include arrangements and are intentionally outside this PR:

- `hotwax-theme/templates/Sept24-Pillar - HUBL.html`
- `HotWax_2021/Templates/BI Reports - Detail HubL.html`
- `HotWax_2021/Templates/Pressroom - Detail HUBL.html`
- `HotWax_2021/Templates/Podcast - Detail HUBL.html`

Changing the OMS product page schema type from `Article` to `SoftwareApplication` remains separate in [PM-358](https://hotwax-team.atlassian.net/browse/PM-358), because that JSON-LD is stored in HubSpot page settings rather than this repository.

## Revert

To revert only the `user_head_overrides` removal, revert commit `07ba4ba`.

To restore the complete pre-PR layout, revert both `07ba4ba` and `3569ade`.

[PM-357]: https://hotwax-team.atlassian.net/browse/PM-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-352]: https://hotwax-team.atlassian.net/browse/PM-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-358]: https://hotwax-team.atlassian.net/browse/PM-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ