### PR TITLE
PM-376: emit the required head payload once, in the head, on the BI report and pressroom templates

### DIFF
--- a/HotWax_2021/Templates/BI Reports - Detail HubL.html
+++ b/HotWax_2021/Templates/BI Reports - Detail HubL.html
@@ -17,7 +17,7 @@
 
     {{ require_css(get_asset_url("/hotwax-theme/css/main.css")) }} 
   
-    {{ required_head_tags }}
+    {{ standard_header_includes }}
     {{ require_css(get_asset_url("/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css")) }}
     {{ require_js(get_asset_url("/HotWax_2021/Code Files/Hotwax-Script-2021.js")) }}
     {{ user_head_overrides }}
@@ -26,7 +26,8 @@
 
 <body class="whitepapaer-post {{ builtin_body_classes }}" style="">
     {% block header %}
-        {{ standard_header_includes }}
+        {# PM-376: standard_header_includes moved to the head above, do not add it back here.
+           It emits the whole HubSpot required head payload, and canonical is only honored in the head. #}
         {% global_partial path="/hotwax-theme/templates/partials/simple-header.html" %}
     {% endblock header %}
     

--- a/HotWax_2021/Templates/Pressroom - Detail HUBL.html
+++ b/HotWax_2021/Templates/Pressroom - Detail HUBL.html
@@ -15,7 +15,7 @@
 
     {{ require_css(get_asset_url("/hotwax-theme/css/main.css")) }} 
   
-    {{ required_head_tags }}
+    {{ standard_header_includes }}
     {{ require_css(get_asset_url("/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css")) }}
     {{ require_js(get_asset_url("/HotWax_2021/Code Files/Hotwax-Script-2021.js")) }}
     {{ user_head_overrides }}
@@ -23,7 +23,8 @@
 </head>
 <body class=" {{ builtin_body_classes }}" style="">
     {% block header %}
-        {{ standard_header_includes }}
+        {# PM-376: standard_header_includes moved to the head above, do not add it back here.
+           It emits the whole HubSpot required head payload, and canonical is only honored in the head. #}
         {% global_partial path="/hotwax-theme/templates/partials/simple-header.html" %}
     {% endblock header %}
 


### PR DESCRIPTION
Part of [PM-376](https://hotwax-team.atlassian.net/browse/PM-376). Continues the work started in [PM-357](https://hotwax-team.atlassian.net/browse/PM-357) ([PR #95](https://github.com/hotwax/hotwax-commerce-website/pull/95), still open and independent of this one).

Affects roughly 42 URLs: the BI report and pressroom detail pages.

## What was wrong

Both templates called `standard_header_includes` and `required_head_tags`. Each variable renders the whole HubSpot required head payload on its own, so every page built on them shipped two copies of it: the canonical tag, the viewport tag, the Open Graph and Twitter tags, jQuery, the whole analytics stack, the collected stylesheet links, and the automatic `BlogPosting` JSON-LD.

PM-357 fixed the same bug in `templates/layouts/base.html`, which covers the templates that extend the shared layout. These two carry it independently.

## One important difference from PM-357

In `base.html` both variables sat inside the `<head>`, so deleting either one was safe and the fix was a one line delete.

These two templates are not built that way. `required_head_tags` is inside the `<head>`, and `standard_header_includes` is inside the `<body>`, in the header block. Deleting `required_head_tags` and keeping the body call, which is what the ticket first suggested, would have left the only emission in the body. Google accepts `rel="canonical"` [only when it appears in the head](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls), so that would have dropped the canonical from the position Google reads and moved the viewport tag out of the head too. That is a regression, not a fix.

This PR emits the payload once, in the head, using the variable HubSpot documents. `standard_header_includes` is [documented as belonging in the head](https://developers.hubspot.com/docs/reference/cms/hubl/variables) and is listed as a required page template variable. `required_head_tags` does not appear in that reference at all.

## Before and after

Same change in both files.

| Where | Before | After |
|---|---|---|
| Inside `<head>` | `{{ required_head_tags }}` | `{{ standard_header_includes }}` |
| Inside `<body>`, in `{% block header %}` | `{{ standard_header_includes }}` | short guard comment in its place |

| Template | Path |
|---|---|
| Pressroom Detail | `HotWax_2021/Templates/Pressroom - Detail HUBL.html` |
| BI Reports Detail | `HotWax_2021/Templates/BI Reports - Detail HubL.html` |

Both live in `HotWax_2021/Templates/`, not in `hotwax-theme/`. The ticket named only `hotwax-theme`. Both themes deploy from the same release workflow.

One extra effect on `BI Reports - Detail HubL.html`, which is not visible in the diff below. Live still calls `require_css` for `Device Styles.css`, and git dropped that call in the earlier device styles migration. The asset moved into `hotwax-theme/css/_devices.css` and no longer exists, so live currently renders a stylesheet link with an empty `href`. Deploying this file therefore also clears that empty link. That is intended, and it is the only line where this branch differs from the live published file.

## What this fixes, measured

| Check | Before | After |
|---|---|---|
| Canonical tags | 2 | 1 |
| Viewport tags | 2 | 1 |
| `og:url` | 2 | 1 |
| jQuery | 2 | 1 |
| `BlogPosting` JSON-LD | 2 | 1 |

The duplicate `BlogPosting` JSON-LD is worth calling out on its own. HubSpot generates that schema automatically, and right now every BI report and pressroom page ships it twice. Duplicate schema on a page is a live defect, and this takes it from 2 to 1 across all roughly 42 URLs.

## Two real rendering changes to eyeball after the release

**1. The stale `main.min.css` copy stops winning the cascade.** The two payloads on these templates are not identical. They ship different revisions of `main.min.css`: the head emits `.../1785501275961/...` and the body emits `.../1784025180938/...`, both 168 KB, both returning HTTP 200. Today the older copy loads second and wins the cascade. After this change only the newer one loads, so it wins. That is the correct end state, and it is a genuine visual change rather than a no-op. Please eyeball one BI report page and one pressroom page after the release.

**2. Analytics counts on these pages will step down.** The duplicated payload fires the whole analytics stack twice: `ga('send','pageview')` for UA-4968436-8, `gtag('config','G-JX2NME6PTK')`, and the Clearbit tag. Once the duplicate is gone, GA4 and UA numbers on these pages will drop, possibly by around half. No traffic is lost. This is a measurement correction, and the old numbers were inflated. Worth annotating the GA4 baseline on release day, because /seo-monitor will otherwise read the drop as an anomaly.

## What is deliberately not in this PR

The pillar and podcast detail templates have the same bug. They are left untouched here on purpose.

Both files have drifted a long way from the live published templates, and the deploy unit is the whole file, so editing them would push git's stale version over live-only work:

| Template | Diff vs live | What shipping git would break |
|---|---|---|
| `Podcast - Detail HUBL.html` | 578 lines | Live has a `require_css` for FontAwesome `all.css` that has never existed in git. This template does not extend `base.html`, so that live-only line is the only thing loading FontAwesome on podcast pages. Shipping git's copy breaks the social share icons on roughly 37 pages. |
| `Sept24-Pillar - HUBL.html` | 444 lines | Live has the cleaned up grid, with the `widget-span widget-type-cell` wrappers gone and a bare `<body>`. Git still has the wrappers. That cleanup lives only on live because PR #84 is still open. Shipping git's copy reverts the mobile grid cleanup. |

That drift is a pre-existing hazard for any release, not something this PR created, and deciding how to resolve it, including whether the cleanup in PR #84 is canonical, is a human call. It is being tracked separately rather than pulled into an SEO PR.

## Testing

`npx playwright test` on this branch: **7 passed (4.4s)**.

Being straight about what that does and does not prove. The suite points at `https://www.hotwax.co` (see `baseURL` in `playwright.config.ts`), so it checks the live site for 404s. It does not render this branch, so it cannot confirm this change. On this run the sitemap request returned 429, so it fell back to the 7 core URLs instead of adding 20 sampled ones.

Rendered verification is not possible before deploy, because the HubSpot page editor preview renders the theme in the portal rather than this branch. Please re-count canonical, viewport and JSON-LD on one page per template after the release. Each should be exactly 1.

## Deploying

Merging this deploys nothing. The workflow runs only when a Release is published, so going live is two separate actions. Not merging and not cutting a release here.


[PM-376]: https://hotwax-team.atlassian.net/browse/PM-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-357]: https://hotwax-team.atlassian.net/browse/PM-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ