### PR TITLE
PM-323: add intrinsic dimensions to module images

### DIFF
--- a/hotwax-theme/modules/cards-no-animation.module/module.html
+++ b/hotwax-theme/modules/cards-no-animation.module/module.html
@@ -55,7 +55,7 @@
             {% if module.add_image && item.image.src%}
               {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}"' %}
               {% if item.image.size_type == 'auto' %}
-                {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+                {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}" style="max-width: 100%; height: auto;"' %}
               {% elif item.image.size_type == 'auto_custom_max' %}
                 {% set sizeAttrs = 'width="{{ item.image.max_width }}" height="{{ item.image.max_height }}" style="max-width: 100%; height: auto;"' %}
               {% endif %}

--- a/hotwax-theme/modules/cards.module/module.html
+++ b/hotwax-theme/modules/cards.module/module.html
@@ -51,7 +51,7 @@
             {% if module.add_image && item.image.src%}
               {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}"' %}
               {% if item.image.size_type == 'auto' %}
-                {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+                {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}" style="max-width: 100%; height: auto;"' %}
               {% elif item.image.size_type == 'auto_custom_max' %}
                 {% set sizeAttrs = 'width="{{ item.image.max_width }}" height="{{ item.image.max_height }}" style="max-width: 100%; height: auto;"' %}
               {% endif %}

--- a/hotwax-theme/modules/counter.module/module.html
+++ b/hotwax-theme/modules/counter.module/module.html
@@ -40,7 +40,7 @@
         {% if item.image.src %}
           {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}"' %}
           {% if item.image.size_type == 'auto' %}
-            {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+            {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}" style="max-width: 100%; height: auto;"' %}
           {% elif item.image.size_type == 'auto_custom_max' %}
             {% set sizeAttrs = 'width="{{ item.image.max_width }}" height="{{ item.image.max_height }}" style="max-width: 100%; height: auto;"' %}
           {% endif %}

--- a/hotwax-theme/modules/featured-image.module/module.html
+++ b/hotwax-theme/modules/featured-image.module/module.html
@@ -19,7 +19,7 @@
   {% if module.image.src %}
     {% set sizeAttrs = 'width="{{ module.image.width }}" height="{{ module.image.height }}"' %}
     {% if module.image.size_type == 'auto' %}
-      {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+      {% set sizeAttrs = 'width="{{ module.image.width }}" height="{{ module.image.height }}" style="max-width: 100%; height: auto;"' %}
     {% elif module.image.size_type == 'auto_custom_max' %}
       {% set sizeAttrs = 'width="100%" height="auto" style="max-width: {{ module.image.max_width }}px; max-height: {{ module.image.max_height }}px"' %}
     {% endif %}

--- a/hotwax-theme/modules/flip-cards.module/module.html
+++ b/hotwax-theme/modules/flip-cards.module/module.html
@@ -14,7 +14,7 @@
             {% if item.front.image.src %}
               {% set sizeAttrs = 'width="{{ item.front.image.width }}" height="{{ item.front.image.height }}"' %}
               {% if item.front.image.size_type == 'auto' %}
-                {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+                {% set sizeAttrs = 'width="{{ item.front.image.width }}" height="{{ item.front.image.height }}" style="max-width: 100%; height: auto;"' %}
               {% elif item.front.image.size_type == 'auto_custom_max' %}
                 {% set sizeAttrs = 'width="{{ item.front.image.max_width }}" height="{{ item.front.image.max_height }}" style="max-width: 100%; height: auto;"' %}
               {% endif %}
@@ -47,7 +47,7 @@
             {% if item.back.image.src %}
               {% set sizeAttrs = 'width="{{ item.back.image.width }}" height="{{ item.back.image.height }}"' %}
               {% if item.back.image.size_type == 'auto' %}
-                {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+                {% set sizeAttrs = 'width="{{ item.back.image.width }}" height="{{ item.back.image.height }}" style="max-width: 100%; height: auto;"' %}
               {% elif item.back.image.size_type == 'auto_custom_max' %}
                 {% set sizeAttrs = 'width="{{ item.back.image.max_width }}" height="{{ item.back.image.max_height }}" style="max-width: 100%; height: auto;"' %}
               {% endif %}

--- a/hotwax-theme/modules/hero-slider.module/module.html
+++ b/hotwax-theme/modules/hero-slider.module/module.html
@@ -5,7 +5,7 @@
     {% if item.image.src %}
     {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}"' %}
     {% if item.image.size_type == 'auto' %}
-    {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+    {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}" style="max-width: 100%; height: auto;"' %}
     {% elif item.image.size_type == 'auto_custom_max' %}
     {% set sizeAttrs = 'width="{{ item.image.max_width }}" height="{{ item.image.max_height }}" style="max-width: 100%; height: auto;"' %}
     {% endif %}

--- a/hotwax-theme/modules/icon-list.module/module.html
+++ b/hotwax-theme/modules/icon-list.module/module.html
@@ -28,7 +28,7 @@
           {% if item.image_icon.src %}
             {% set sizeAttrs = 'width="{{ item.image_icon.width }}" height="{{ item.image_icon.height }}"' %}
             {% if item.image_icon.size_type == 'auto' %}
-              {% set sizeAttrs = 'style="max-width: unset; height: unset;"' %}
+              {% set sizeAttrs = 'width="{{ item.image_icon.width }}" height="{{ item.image_icon.height }}" style="max-width: unset; height: unset;"' %}
             {% elif item.image_icon.size_type == 'auto_custom_max' %}
               {% set sizeAttrs = 'style="max-width: {{ item.image_icon.max_width }}px; max-height: {{ item.image_icon.max_height }}px"' %}
             {% endif %}

--- a/hotwax-theme/modules/image-text.module/module.html
+++ b/hotwax-theme/modules/image-text.module/module.html
@@ -78,7 +78,7 @@
           {% if module.image.src %}
             {% set sizeAttrs = 'width="{{ module.image.width }}" height="{{ module.image.height }}"' %}
             {% if module.image.size_type == 'auto' %}
-              {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+              {% set sizeAttrs = 'width="{{ module.image.width }}" height="{{ module.image.height }}" style="max-width: 100%; height: auto;"' %}
             {% elif module.image.size_type == 'auto_custom_max' %}
               {% set sizeAttrs = 'width="100%" height="auto" style="max-width: {{ module.image.max_width }}px; max-height: {{ module.image.max_height }}px"' %}
             {% endif %}

--- a/hotwax-theme/modules/logo-slider.module/module.html
+++ b/hotwax-theme/modules/logo-slider.module/module.html
@@ -9,7 +9,7 @@
                   {% if item.image.src %}
                     {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}"' %}
                     {% if item.image.size_type == 'auto' %}
-                      {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+                      {% set sizeAttrs = 'width="{{ item.image.width }}" height="{{ item.image.height }}" style="max-width: 100%; height: auto;"' %}
                     {% elif item.image.size_type == 'auto_custom_max' %}
                       {% set sizeAttrs = 'width="100%" height="auto" style="max-width: {{ item.image.max_width }}px; max-height: {{ item.image.max_height }}px"' %}
                     {% endif %}

--- a/hotwax-theme/modules/video-popup.module/module.html
+++ b/hotwax-theme/modules/video-popup.module/module.html
@@ -3,7 +3,7 @@
   {% if module.video_thumbnail.src %}
     {% set sizeAttrs = 'width="{{ module.video_thumbnail.width }}" height="{{ module.video_thumbnail.height }}"' %}
     {% if module.video_thumbnail.size_type == 'auto' %}
-      {% set sizeAttrs = 'style="max-width: 100%; height: auto;"' %}
+      {% set sizeAttrs = 'width="{{ module.video_thumbnail.width }}" height="{{ module.video_thumbnail.height }}" style="max-width: 100%; height: auto;"' %}
     {% elif module.video_thumbnail.size_type == 'auto_custom_max' %}
       {% set sizeAttrs = 'width="100%" height="auto" style="max-width: {{ module.video_thumbnail.max_width }}px; max-height: {{ module.video_thumbnail.max_height }}px"' %}
     {% endif %}


### PR DESCRIPTION
## Summary

Adds explicit `width` and `height` attributes to HubSpot module images when the image field uses HubSpot's `auto` size mode.

## Why

Without intrinsic image dimensions, the browser cannot reserve the correct image space before the asset loads. That can contribute to layout shift. This keeps the existing responsive styling while giving the browser the dimensions it needs for better CLS behavior.

## Scope

Updates only module templates that already had image rendering logic:

- cards-no-animation
- cards
- counter
- featured-image
- flip-cards
- hero-slider
- icon-list
- image-text
- logo-slider
- video-popup

## Validation

- Confirmed this branch changes only 10 module template files.
- Reviewed the diff: each change adds existing HubSpot image width/height values to `sizeAttrs` for `size_type == 'auto'`.
- No HubSpot upload/publish was performed as part of this PR creation.
