### PR TITLE
PM-431 (partial): add the live-only FontAwesome require to the podcast template. Does not resolve the drift

### DIFF
--- a/HotWax_2021/Templates/Podcast - Detail HUBL.html
+++ b/HotWax_2021/Templates/Podcast - Detail HUBL.html
@@ -14,6 +14,7 @@
     <meta name="description" content="{{ page_meta.meta_description }}">
 
     {{ require_css(get_asset_url("/hotwax-theme/css/main.css")) }} 
+    {{ require_css("https://use.fontawesome.com/releases/v5.15.4/css/all.css") }}
   
     {{ required_head_tags }}
     {{ require_css(get_asset_url("/HotWax_2021/Code Files/Hotwax_Stylesheet_2021.css")) }}


### PR DESCRIPTION
Partial work on [PM-431](https://hotwax-team.atlassian.net/browse/PM-431).

## Read this first

**This PR does not resolve PM-431 and merging it does not make a Release safe.** It closes one line of a drift that I have now measured at 32 files. Please do not close PM-431 on it.

I opened this while the drift looked like a one line problem. It is not. The full audit below is the real result of this ticket, and it is the reason this PR is deliberately labelled partial.

## What this PR changes

One additive line in `HotWax_2021/Templates/Podcast - Detail HUBL.html`:

```
{{ require_css("https://use.fontawesome.com/releases/v5.15.4/css/all.css") }}
```

The line already exists on live. It does not exist in `main`. The template does not extend `base.html`, so it does not inherit the FontAwesome require that `base.html` carries, and the sidebar share icons depend on it. After this change the head block is byte identical to live.

The line is also already present, at the same place, in open [PR 84](https://github.com/hotwax/hotwax-commerce-website/pull/84). This PR is a strict subset of PR 84. I test merged PR 84 on top of this branch and it merged clean, so this does not block PR 84 either way.

## The real finding: `main` and live differ on 32 files

I fetched the entire live published theme through the HubSpot CLI and diffed it against `upstream/main`. This is a read only fetch. No writes were made to live.

Result: 574 files in git, 589 on live, **32 files differ**. The drift runs in both directions, so this cannot be fixed by copying either side wholesale.

Largest drifts by changed lines:

| Changed lines | File |
| --- | --- |
| 542 | `HotWax_2021/Templates/Podcast - Detail HUBL.html` |
| 387 | `hotwax-theme/templates/Sept24-Pillar - HUBL.html` |
| 341 | `hotwax-theme/templates/product-updates-index.html` |
| 165 | `Pillar - Section Header.module/fields.json` |
| 149 | `hotwax-theme/templates/product-update-post.html` |
| 111 | `Pillar - Table of Contents - Live.module/module.html` |
| 94 | `Pillar - Section Header.module/module.html` |
| 34 | `hotwax-theme/templates/layouts/base.html` |
| 29 | `hotwax-theme/templates/partials/simple-header.html` |
| 21 | `HotWax_2021/Code Files/CustomGrid.css` |

A further 22 files differ by 1 to 18 lines, including `hotwax-theme/js/main.js`, `_blog.css`, `_cards.css`, `_reset.css`, `blog-post.html`, both other `HotWax_2021` templates, and several module `meta.json` and `fields.json` files.

`product-updates-index.html` and `product-update-post.html` are large drifts that appear in no open PR. I have not traced where they came from.

## How live got ahead: open PRs are being deployed without being merged

I checked each open PR's files against live:

| PR | Theme files | Files where live matches the PR | Files where live matches `main` |
| --- | --- | --- | --- |
| [84](https://github.com/hotwax/hotwax-commerce-website/pull/84) | 14 | **9** | 1 |
| [94](https://github.com/hotwax/hotwax-commerce-website/pull/94) | 1 | **1** | 0 |
| [88](https://github.com/hotwax/hotwax-commerce-website/pull/88) | 1 | 0 | 0 |
| [95](https://github.com/hotwax/hotwax-commerce-website/pull/95) | 1 | 0 | 0 |
| [96](https://github.com/hotwax/hotwax-commerce-website/pull/96) | 2 | 0 | 0 |
| [98](https://github.com/hotwax/hotwax-commerce-website/pull/98) | 10 | 0 | 10 |

Two open PRs are already running in production. PR 84's podcast template is byte identical to live across all 465 lines and 27,148 bytes: the MD5 of the PR file, of the live file I fetched, and the content hash HubSpot's own metadata API reports are all `5aae110a41794ccaca99644e63f6ee45`. The live file was last written at 15:05 UTC on 23 May, 36 minutes after PR 84 was opened at 14:29 UTC the same day. PR 94's single file is likewise byte identical to live.

For PR 88, PR 95 and PR 96, live matches neither the PR nor `main`. Live is a third state carrying part of that work plus further edits made only on live.

PR 98 is clean. Live matches `main` on all 10 of its files.

A 465 line byte identical match with a branch is a programmatic push, not hand editing in Design Manager. **I could not establish who did it or with which tool.** The HubSpot audit log endpoints return `MISSING_SCOPES` for the current access key, and the Source Code API gives a modification time but no author. Confirming the actor needs the audit log scope added to the key, or a human reading the account activity log and Design Manager revision history in the HubSpot UI.

## Decisions for a human

None of these are mine to make.

**1. Whether to merge this PR at all.** It is a one line safety net for one of 32 drifted files. Merge it if you want the podcast icons protected in case a Release is cut before the full reconciliation. Close it if you would rather do the reconciliation properly in one pass. Either is reasonable. It should not be treated as the PM-431 fix.

**2. [PR 84](https://github.com/hotwax/hotwax-commerce-website/pull/84).** Nine of its files are already live. Merging it aligns `main` to live for those. Note it also carries pillar work that is *not* live, so it needs a real review, not a rubber stamp.

**3. The canonical pillar version.** Live is not equal to PR 84 for `Sept24-Pillar - HUBL.html`. Live is PR 84 plus two changes that exist in no branch: `no_wrapper=true` on 9 rich text module blocks, and in the inline style block `.section-body, .pillar-intro` changed from `padding-inline: var(--spacer-md)` to `padding: var(--spacer-md)` plus `padding-block-end: var(--spacer-lg)`. Recommendation: fold those into PR 84 before merging, or merging and releasing will revert them. I am not deciding which version is canonical.

**4. PM-357 and [PR 95](https://github.com/hotwax/hotwax-commerce-website/pull/95).** Live `base.html` matches neither PR 95 nor `main`. It carries the head dedupe *and* an AOS change that is in no branch: `aos.js` loaded with `{defer: true}` and `AOS.init` moved inside `DOMContentLoaded`. That overlaps [PR 88](https://github.com/hotwax/hotwax-commerce-website/pull/88), which is also still open. Live `base.html` was last written on 11 August, after PM-431 was filed. Recommendation: reconcile PR 88 and PR 95 against live together, then correct PM-357's status. I am not deciding this one.

**5. `BI Reports` and `Pressroom`.** Both drift, and PM-431 recorded Pressroom as clean, which is no longer true. Live has the head fix on both; `main` does not. `main` has the removal of the dead `Device Styles.css` require; live does not, and I confirmed that asset is gone because the Source Code API returns 404 for it, so live currently ships `<link rel="stylesheet" href="">` on BI report pages. This needs a merge of both sides, not a copy of either. The same dead asset also explains several `Device` module `meta.json` drifts.

## Verification

Live source was read through the HubSpot Source Code API and `hs cms fetch`. Reads only. Nothing was written to live, nothing merged, no Release cut.

Playwright: the suite in this repo points at `https://www.hotwax.co`, so it exercises the live site and cannot verify an undeployed template change. Run for a baseline: 5 passed, 2 failed. Both failures are pre-existing live 404s on https://www.hotwax.co/omnichannel-order-management-system and https://www.hotwax.co/netsuite-shopify-integration, unrelated to this change and present on `main` too. There is no test here that proves this template renders correctly. That only happens after a deploy.

Separately worth a ticket: live podcast pages currently emit two canonical tags, two viewport tags and two `og:url` tags, because the template has both `required_head_tags` in the head and `standard_header_includes` in the body. PR 96 fixes exactly this on BI Reports and Pressroom but excludes the podcast and pillar templates.


[PM-431]: https://hotwax-team.atlassian.net/browse/PM-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ