### PR TITLE
PM-454: backport live css_render_options async to Device and GraphicFrame meta.json

### DIFF
--- a/HotWax_2021/Custom Modules/Device/DeviceFrame.module/meta.json
+++ b/HotWax_2021/Custom Modules/Device/DeviceFrame.module/meta.json
@@ -5,6 +5,9 @@
   } ],
   "global" : false,
   "content_types" : [ "LANDING_PAGE", "SITE_PAGE" ],
+  "css_render_options" : {
+    "async" : true
+  },
   "categories" : [ "DESIGN", "BODY_CONTENT" ],
   "host_template_types" : [ "PAGE" ],
   "module_id" : 115826539898,

--- a/HotWax_2021/Custom Modules/Device/GraphicFrame.module/meta.json
+++ b/HotWax_2021/Custom Modules/Device/GraphicFrame.module/meta.json
@@ -8,6 +8,9 @@
   } ],
   "global" : false,
   "content_types" : [ "LANDING_PAGE", "SITE_PAGE" ],
+  "css_render_options" : {
+    "async" : true
+  },
   "categories" : [ "DESIGN", "BODY_CONTENT", "MEDIA" ],
   "host_template_types" : [ "PAGE" ],
   "module_id" : 129018699413,


### PR DESCRIPTION
Jira: [PM-454](https://hotwax-team.atlassian.net/browse/PM-454)

## What this is

This is a backport of a change that is **already live on hotwax.co**. It is a **no-op for production behavior**. The only purpose is to stop the next Release from reverting it.

## Why it is needed

On 13 Aug 2026 a `meta.json` change was pushed straight to live HubSpot for two modules, adding `css_render_options.async: true`. That change never reached this repo.

The prod deploy workflow (`.github/workflows/hubspot_prod.yml`) runs on `release: published` and deploys the whole `HotWax_2021` and `hotwax-theme` directories. It deploys whole files, not diffs, so the next published Release would overwrite the live `meta.json` with the repo version, silently dropping the async flag, with nothing in the diff to warn the reviewer.

Both modules ship a `module.css`, so the flag is meaningful. With `async: true` the module CSS loads asynchronously instead of blocking render.

## Before and after

Live published source was re-read read-only today via the Source Code API for account 6357099, at the time of this commit.

| File | Live published source | main before this PR | This PR |
| --- | --- | --- | --- |
| HotWax_2021/Custom Modules/Device/DeviceFrame.module/meta.json | has `css_render_options.async: true` | no `css_render_options` key | adds the key, matching live |
| HotWax_2021/Custom Modules/Device/GraphicFrame.module/meta.json | has `css_render_options.async: true` | no `css_render_options` key | adds the key, matching live |

The added block in both files:

```json
  "css_render_options" : {
    "async" : true
  },
```

It sits after `content_types` and before `categories`, which is the position live uses in both files. Existing formatting and key order are untouched.

## What was verified

- Both files parse as valid JSON.
- The diff against `main` is 6 added lines across 2 files and nothing else. No other file is touched.
- After the edit, each file is semantically equal to the live published JSON, and the key order matches live exactly.
- Confirmed the prod workflow deploys `HotWax_2021`, so the revert risk is real and not theoretical.

## What was not verified

- No Playwright run. This is a metadata backport with no production behavior change, since production already has these exact values. Running the suite would only confirm the current live behavior, which is already the shipped state.
- No performance re-measurement. The performance gain recorded on the ticket came from the original live push, not from this PR.

## Scope

One finding, one PR. This does not touch the wider drift reconciliation in [PM-431](https://hotwax-team.atlassian.net/browse/PM-431), and it does not touch the direct-write policy question in [PM-443](https://hotwax-team.atlassian.net/browse/PM-443), which is on Hold pending a human decision.

## Shipping

Merging this does not go live. Going live needs a human to publish a GitHub Release. This one should be merged **before** the next Release, not after.


[PM-454]: https://hotwax-team.atlassian.net/browse/PM-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-431]: https://hotwax-team.atlassian.net/browse/PM-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ